### PR TITLE
Deterministically compress files

### DIFF
--- a/whitenoise/gzip.py
+++ b/whitenoise/gzip.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, print_function, division, unicode_litera
 import argparse
 import gzip
 import os
+import os.path
 import re
 
 
@@ -43,7 +44,7 @@ def main(root, extensions=None, quiet=False, log=print):
 def compress(path, log):
     gzip_path = path + '.gz'
     with open(path, 'rb') as in_file:
-        with gzip.open(gzip_path, 'wb', compresslevel=9) as out_file:
+        with gzip.GzipFile(gzip_path, 'wb', compresslevel=9, mtime=os.path.getmtime(path)) as out_file:
             for chunk in iter(lambda: in_file.read(CHUNK_SIZE), b''):
                 out_file.write(chunk)
     # If gzipped file isn't actually any smaller then get rid of it


### PR DESCRIPTION
Gzip contains a timestamp in the compressed stream. If you don't explicitly give it one then the Python module will include the current time instead. This means that if you just blindly compress everything anytime a file changes and try to commit those artifacts then you end up with a new .gz file everytime. This change will make it so that the output is the same as long as the files are the same (including modification time).

If you accept this I'd love a new release with it as well :)
