### PR TITLE
Add GZIP option to collect static

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ QuickStart: Django application
 In ``wsgi.py``:
 
 .. code-block:: python
-   
+
    from django.core.wsgi import get_wsgi_application
    from whitenoise.django import DjangoWhiteNoise
 
@@ -120,6 +120,11 @@ your ``STATIC_ROOT`` directory. (Note that you'll need to add ``whitenoise`` to 
       --traceback           Print traceback on exception
       --version             show program's version number and exit
       -h, --help            show this help message and exit
+
+If you want ``gzipstatic`` to be run by default after ``collectstatic``
+set ``WHITENOISE_GZIP_COLLECTSTATIC`` to something truthy and make sure
+``whitenoise`` is listed after ``django.contrib.staticfiles`` in your
+``INSTALLED_APPS``.
 
 
 Infrequently Asked Questions

--- a/tests/test_django_collectstatic_gzip.py
+++ b/tests/test_django_collectstatic_gzip.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+from django.conf import settings
+from django.core.management import call_command
+
+from .test_gzip import GzipTest
+
+
+@override_settings()
+class DjangoCollectStaticGzipTest(GzipTest, SimpleTestCase):
+
+    @classmethod
+    def run_gzip(cls):
+        settings.STATIC_ROOT = cls.tmp
+        settings.WHITENOISE_GZIP_COLLECTSTATIC = True
+        call_command('collectstatic', interactive=False, verbosity=0)

--- a/whitenoise/management/commands/collectstatic.py
+++ b/whitenoise/management/commands/collectstatic.py
@@ -1,0 +1,28 @@
+# Command mostly copied from django-storages fast collectstatic commadn
+# https://bitbucket.org/maikhoepfel/django-storages/src/c99a01da29a959a3c919ab3e3debbf74abab5b85/storages/management/commands/collectstatic.py
+
+from django.conf import settings
+from django.contrib.staticfiles.management.commands import collectstatic
+from django.core.management import call_command
+
+
+class Command(collectstatic.Command):
+    """
+    This management command adds support to create GZIP versions of collected
+    static files, by calling the `gzipstatic` command. It's custom behaviour
+    is disabled by default; you explicitly need to set
+    WHITENOISE_GZIP_COLLECTSTATIC to enable.
+    """
+
+    def collect(self):
+        """
+        Ensure that the storage class preloads the metadata. This is where the
+        actual speedup comes from, as one request can pull the file hashes for
+        many or all files in the bucket.
+        """
+        original_return = super(Command, self).collect()
+
+        if getattr(settings, 'WHITENOISE_GZIP_COLLECTSTATIC', False):
+            call_command('gzipstatic', verbosity=self.verbosity)
+
+        return original_return


### PR DESCRIPTION
I think it would make sense to have an option to run `gzipstatic` after `collectstatic`. I have added this feature under an optional setting `WHITENOISE_GZIP_COLLECTSTATIC`. 

It might seem to be a little weird to override the collectstatic command, but it seems to somewhat of an accepted practice. django-storages [just did the same thing](https://bitbucket.org/david/django-storages/pull-request/89/add-fast-collectstatic-management-command/diff#comment-1357341) with their fast collectstatic command. South also does the same with `syncdb`.

I think my code is right, but I can not get the tests to pass. It must have something to do with the shared `setUpClass` and `tearDownClass` methods, because my new tests pass fine, but they break existing tests. When I comment out my tests, or change the call from `collecstatic` to  `gzipstatic`, the other tests pass as well. I tried to figure out how it breaks the other tests, but was unable. I also made a go at refactoring the tests to change the `setUpClass` to `setUp` to see if that would make the tests less dependent on the state of others, but that seemed to break things as well. Would love to get some feedback or ideas on what to do.
