### PR TITLE
Spelling in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ features for Django.
 WhiteNoise takes care of best-practices for you, for instance:
 
 * Serving gzipped content (handling Accept-Encoding and Vary headers correctly)
-* Settting far-future cache headers on content which won't change
+* Setting far-future cache headers on content which won't change
 
 Worried that serving static files with Python is horribly inefficient?
 Still think you should be using Amazon S3? Have a look at the `Infrequently


### PR DESCRIPTION
Change:
- **Settting** far-future cache headers on content which won't change

to
- **Setting** far-future cache headers on content which won't change
