### PR TITLE
Don't throw on empty files

### DIFF
--- a/whitenoise/gzip.py
+++ b/whitenoise/gzip.py
@@ -71,6 +71,8 @@ def compress(path, log=null_log):
 
 
 def is_worth_gzipping(orig_size, gzip_size):
+    if orig_size == 0:
+        return False
     ratio = gzip_size / orig_size
     return ratio <= 0.95
 


### PR DESCRIPTION
Attempting to compress an empty file will make white noise throw a division by 0 exception, since the empty file's size is 0, and the ratio is computed by division.

Empty files obviously don't need compression anyway, so we can just get rid of it.

One might ask, "Why have an empty file in the static dir?" See heroku's [guide](https://devcenter.heroku.com/articles/django-assets) for serving static assets with heroku: 

> Django won’t automatically create the collectstatic target directory, so we recommend adding a dummy file to your repository ...
