### PR TITLE
Enable debug reloading

### DIFF
--- a/whitenoise/django.py
+++ b/whitenoise/django.py
@@ -34,10 +34,11 @@ class DjangoWhiteNoise(WhiteNoise):
             except AttributeError:
                 pass
         static_root, static_prefix = self.get_static_root_and_prefix()
-        self.static_prefix = static_prefix
-        root = getattr(settings, 'WHITENOISE_ROOT', None)
-        super(DjangoWhiteNoise, self).__init__(application, root=root)
-        self.add_files(static_root, prefix=static_prefix)
+        super(DjangoWhiteNoise, self).__init__(
+            application,
+            root=static_root,
+            prefix=static_prefix
+        )
 
     def get_static_root_and_prefix(self):
         static_url = getattr(settings, 'STATIC_URL', None)
@@ -55,9 +56,9 @@ class DjangoWhiteNoise(WhiteNoise):
         file with a hash of its contents as part of its name) which can
         therefore be cached forever
         """
-        if not url.startswith(self.static_prefix):
+        if not url.startswith(self.prefix):
             return False
-        name = url[len(self.static_prefix):]
+        name = url[len(self.prefix):]
         name_without_hash = self.get_name_without_hash(name)
         if name == name_without_hash:
             return False


### PR DESCRIPTION
Hiya,

I'm a fan of whitenoise and its approach, but for a few reasons I wound up needing to be able to handle some staticserver-related stuff without reloading the server every time, and personally speaking I don't like making django (even in development) handle serving static/media. I'm definitely aware this isn't 100% the norm, but figured I'd throw my changes over as a pull request anyway.

This does a few things:
- Try to use **[scandir/walk](https://github.com/benhoyt/scandir)** if possible; it's in Python 3.5, and available as a module in Python 2.6+. According to the author of `scandir` it's faster than `os.walk`, and was merged into 3.5 as a result/overhaul. Falls back to `os.walk` if the user happens to not have it.
- If the server is in debug mode (e.g, specifically, if Django is in development mode) and a check for a file in `self.files` fails, it'll re-scan to see if the file was recently added (just requires setting `WHITENOISE_DEBUG` in `settings.py`, which I just pointed at `DEBUG`).

At least for my needs, this isn't intrusive at all and has worked out pretty well so far. While I'm developing it's been much more pleasant to use than the builtin static serving stuff, and in production it functions more or less as originally authored.

I theorize that even if WHITENOISE_DEBUG was set in production with a CDN tossed in front of it that things would likely still run fine, but I've not tested it yet - no real incentive to and haven't thought said theory all the way through. Hope this is something that others would find useful!