### PR TITLE
Report MissingFileError path

### DIFF
--- a/whitenoise/base.py
+++ b/whitenoise/base.py
@@ -35,7 +35,7 @@ def stat_regular_file(path):
         file_stat = os.stat(path)
     except OSError as e:
         if e.errno == errno.ENOENT:
-            raise MissingFileError()
+            raise MissingFileError(path)
         else:
             raise
     if not stat.S_ISREG(file_stat.st_mode):


### PR DESCRIPTION
Using Whitenoise with Django. If my STATIC_ROOT has broken symlinks in it, WhiteNoise will prevent the app from starting by raising a MissingFileError at startup. This patch makes that error more useful by specifying the path of the missing file.

I would also love it if Whitenoise could handle this more gracefully somehow.

Related Django issue: https://code.djangoproject.com/ticket/25346