### PR TITLE
More helpful startup error, avoid barfing on broken css

### DIFF
--- a/whitenoise/base.py
+++ b/whitenoise/base.py
@@ -35,7 +35,7 @@ def stat_regular_file(path):
         file_stat = os.stat(path)
     except OSError as e:
         if e.errno == errno.ENOENT:
-            raise MissingFileError()
+            raise MissingFileError(path)
         else:
             raise
     if not stat.S_ISREG(file_stat.st_mode):

--- a/whitenoise/django.py
+++ b/whitenoise/django.py
@@ -176,6 +176,12 @@ class HelpfulExceptionMixin(object):
         relative paths which might be pointing to the wrong location.
         """)
 
+    def hashed_name(self, name, content=None):
+        try:
+            return super(HelpfulExceptionMixin, self).hashed_name(name, content)
+        except ValueError:
+            return name
+
     def post_process(self, *args, **kwargs):
         files = super(HelpfulExceptionMixin, self).post_process(*args, **kwargs)
         for name, hashed_name, processed in files:


### PR DESCRIPTION
Two (mostly orthogonal) things here. I'm using Whitenoise with Django, and the whitenoise.django.GzipManifestStaticFilesStorage storage backend.

First, if my STATIC_ROOT has broken symlinks in it, WhiteNoise will prevent the app from starting by raising a MissingFileError at startup. This patch makes that error more useful by specifying the path of the missing file. I would also love it if Whitenoise could handle this more gracefully somehow, but this at least lets me know where my problem is.

Second, if I have a CSS file with a broken reference in it, collectstatic bails and some portion of my other files won't get processed. When this happens on prod, this breaks all sorts of things: files aren't written to their hashed names, and if you're running `collectstatic --clear` then they're gone until the next successful collectstatic. My patch allows processing to continue if a referenced file can't be found, so that the only thing broken is the thing that's broken. 

The current fail-fast behavior is cool for debugging my CSS, so it might be nice to have it in a config setting or something like that.

I'd love some feedback on these ideas. Thanks!

Evan