### PR TITLE
Use current standard MIME type for WOFF fonts

### DIFF
--- a/whitenoise/base.py
+++ b/whitenoise/base.py
@@ -70,6 +70,7 @@ class WhiteNoise(object):
     GZIP_SUFFIX = '.gz'
     ACCEPT_GZIP_RE = re.compile(r'\bgzip\b')
     EXTRA_MIMETYPES = (
+            ('application/font-woff', '.woff'),
             ('font/woff2', '.woff2'),)
     # All mimetypes starting 'text/' take a charset parameter, plus the
     # additions in this set


### PR DESCRIPTION
The standard MIME type is apparently now `application/font-woff` rather than `application/x-font-woff` currently returned:

http://www.w3.org/TR/WOFF/#appendix-b