### PR TITLE
Test against Django master & cleanup testing configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,13 @@ env:
   matrix:
     - DJANGO_VERSION='Django>=1.8,<1.9'
     - DJANGO_VERSION='Django>=1.9,<1.10'
+    - DJANGO_VERSION=https://github.com/django/django/archive/master.tar.gz
 matrix:
   include:
     - python: 3.3
       env: DJANGO_VERSION='Django>=1.8,<1.9'
-
+  allow_failures:
+    # Django master is allowed to fail
+    - env: DJANGO_VERSION=https://github.com/django/django/archive/master.tar.gz
   fast_finish: true
 script: python -m unittest discover

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - pypy
@@ -15,9 +14,9 @@ env:
     - DJANGO_VERSION='Django>=1.8,<1.9'
     - DJANGO_VERSION='Django>=1.9,<1.10'
 matrix:
-  exclude:
+  include:
     - python: 3.3
-      env: DJANGO_VERSION='Django>=1.9,<1.10'
+      env: DJANGO_VERSION='Django>=1.8,<1.9'
 
   fast_finish: true
 script: python -m unittest discover

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 2.7
   - 3.3
   - 3.4
+  - 3.5
   - pypy
 install: travis_retry pip install 'requests>=2.9,<2.10' $DJANGO_VERSION
 env:
@@ -14,11 +15,6 @@ env:
     - DJANGO_VERSION='Django>=1.8,<1.9'
     - DJANGO_VERSION='Django>=1.9,<1.10'
 matrix:
-  include:
-    - python: 3.5
-      env: DJANGO_VERSION='Django>=1.8,<1.9'
-    - python: 3.5
-      env: DJANGO_VERSION='Django>=1.9,<1.10'
   exclude:
     - python: 3.3
       env: DJANGO_VERSION='Django>=1.9,<1.10'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# Use the faster container-based infrastructure.
+sudo: false
 language: python
 python:
   - 2.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,15 @@
 [tox]
 envlist =
-  py27-django18,
-  py27-django19,
+  {py27,py34,py35,pypy}-django{18,19},
   py33-django18,
-  py34-django18,
-  py34-django19,
-  py35-django18,
-  py35-django19,
-  pypy-django18,
-  pypy-django19
 
 [testenv]
+basepython =
+  py27: python2.7
+  py33: python3.3
+  py34: python3.4
+  py35: python3.5
+  pypy: pypy
 commands =
   coverage run --branch --include=whitenoise/* -m unittest discover
   coverage report
@@ -21,63 +20,5 @@ setenv =
 deps =
   coverage>=4.0,<4.1
   requests>=2.9,<2.10
-
-[testenv:py27-django18]
-basepython=python2.7
-deps =
-  {[testenv]deps}
-  Django>=1.8,<1.9
-
-[testenv:py27-django19]
-basepython=python2.7
-deps =
-  {[testenv]deps}
-  Django>=1.9,<1.10
-
-[testenv:py33-django18]
-basepython=python3.3
-deps =
-  {[testenv]deps}
-  Django>=1.8,<1.9
-
-[testenv:py33-django19]
-basepython=python3.3
-deps =
-  {[testenv]deps}
-  Django>=1.9,<1.10
-
-[testenv:py34-django18]
-basepython=python3.4
-deps =
-  {[testenv]deps}
-  Django>=1.8,<1.9
-
-[testenv:py34-django19]
-basepython=python3.4
-deps =
-  {[testenv]deps}
-  Django>=1.9,<1.10
-
-[testenv:py35-django18]
-basepython=python3.5
-deps =
-  {[testenv]deps}
-  Django>=1.8,<1.9
-
-[testenv:py35-django19]
-basepython=python3.5
-deps =
-  {[testenv]deps}
-  Django>=1.9,<1.10
-
-[testenv:pypy-django18]
-basepython=pypy
-deps =
-  {[testenv]deps}
-  Django>=1.8,<1.9
-
-[testenv:pypy-django19]
-basepython=pypy
-deps =
-  {[testenv]deps}
-  Django>=1.9,<1.10
+  django18: Django>=1.8,<1.9
+  django19: Django>=1.9,<1.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  {py27,py34,py35,pypy}-django{18,19},
+  {py27,py34,py35,pypy}-django{18,19,master},
   py33-django18,
 
 [testenv]
@@ -22,3 +22,4 @@ deps =
   requests>=2.9,<2.10
   django18: Django>=1.8,<1.9
   django19: Django>=1.9,<1.10
+  djangomaster: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
This PR:
* Makes the Travis run test against the Django master branch, so upcoming breakage can be spotted before an official release. (Failures don't cause the overall Travis run to error out.)
* Switches the Travis job to their faster container infra (saves the 20s boot time per sub-job)
* Cleans up the syntax in .travis.yml and tox.ini (a no-op in terms of behaviour)

See the individual commit diffs/multi-line commit messages for more details.

Many thanks for a great project! :-)