### PR TITLE
Fix flake8 warnings and run it as part of the Travis job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 /htmlcov
 /docs/_build
 /dist
+/*.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
   include:
     - python: 3.3
       env: DJANGO_VERSION='Django>=1.8,<1.9'
+    - python: 2.7
+      env: lint
+      install: travis_retry pip install flake8==2.5.2
+      script: flake8 --show-source
   allow_failures:
     # Django master is allowed to fail
     - env: DJANGO_VERSION=https://github.com/django/django/archive/master.tar.gz

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 # -*- coding: utf-8 -*-
 #
 # WhiteNoise documentation build configuration file, created by

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal = 1
+
+[flake8]
+max-line-length = 100

--- a/tests/django_urls.py
+++ b/tests/django_urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 from django.http import HttpResponse
 
+
 def hello_world(reqeust):
     return HttpResponse(content='Hello Word', content_type='text/plain')
 

--- a/tests/test_django_whitenoise.py
+++ b/tests/test_django_whitenoise.py
@@ -63,14 +63,14 @@ class DjangoWhiteNoiseTest(SimpleTestCase):
         response = self.server.get(url)
         self.assertEqual(response.content, self.static_files.css_content)
         self.assertEqual(response.headers.get('Cache-Control'),
-                'public, max-age={}'.format(DjangoWhiteNoise.FOREVER))
+                         'public, max-age={}'.format(DjangoWhiteNoise.FOREVER))
 
     def test_unversioned_file_not_cached_forever(self):
         url = settings.STATIC_URL + self.static_files.css_path
         response = self.server.get(url)
         self.assertEqual(response.content, self.static_files.css_content)
         self.assertEqual(response.headers.get('Cache-Control'),
-                'public, max-age={}'.format(DjangoWhiteNoise.max_age))
+                         'public, max-age={}'.format(DjangoWhiteNoise.max_age))
 
     def test_get_gzip(self):
         url = storage.staticfiles_storage.url(self.static_files.css_path)

--- a/tests/test_gzip.py
+++ b/tests/test_gzip.py
@@ -5,7 +5,6 @@ import errno
 import gzip
 import os
 import shutil
-import sys
 import tempfile
 from unittest import TestCase
 

--- a/tests/test_gzip.py
+++ b/tests/test_gzip.py
@@ -19,6 +19,7 @@ TEST_FILES = {
     TOO_SMALL_FILE: b'hi',
 }
 
+
 class GzipTestBase(TestCase):
 
     @classmethod
@@ -42,6 +43,7 @@ class GzipTestBase(TestCase):
         super(GzipTestBase, cls).tearDownClass()
         # Remove temporary directory
         shutil.rmtree(cls.tmp)
+
 
 class GzipTest(GzipTestBase):
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -17,6 +17,8 @@ class DjangoWhiteNoiseStorageTest(SimpleTestCase):
             TriggerException().hashed_name('/missing/file.png')
         except ValueError as e:
             exception = e
-        helpful_exception = HelpfulExceptionMixin() \
-                .make_helpful_exception(exception, 'styles/app.css')
+        helpful_exception = HelpfulExceptionMixin().make_helpful_exception(
+                                exception,
+                                'styles/app.css'
+                            )
         self.assertIsInstance(helpful_exception, MissingFileError)

--- a/tests/test_whitenoise.py
+++ b/tests/test_whitenoise.py
@@ -29,17 +29,18 @@ class WhiteNoiseTest(TestCase):
     def setUpClass(cls):
         cls.files = cls.init_files()
         cls.application = CustomWhiteNoise(demo_app,
-                root=cls.files.directory, max_age=1000)
+                                           root=cls.files.directory,
+                                           max_age=1000)
         cls.server = TestServer(cls.application)
         super(WhiteNoiseTest, cls).setUpClass()
 
     @staticmethod
     def init_files():
         return Files('assets',
-            js='subdir/javascript.js',
-            gzip='compressed.css',
-            gzipped='compressed.css.gz',
-            custom_mime='custom-mime.foobar')
+                     js='subdir/javascript.js',
+                     gzip='compressed.css',
+                     gzipped='compressed.css.gz',
+                     custom_mime='custom-mime.foobar')
 
     def test_get_file(self):
         response = self.server.get(self.files.js_url)
@@ -125,7 +126,9 @@ class WhiteNoiseAutorefresh(WhiteNoiseTest):
         cls.tmp = tempfile.mkdtemp()
         # Initialize test application
         cls.application = CustomWhiteNoise(demo_app,
-                root=cls.tmp, max_age=1000, autorefresh=True)
+                                           root=cls.tmp,
+                                           max_age=1000,
+                                           autorefresh=True)
         cls.server = TestServer(cls.application)
         # Copy in the files *after* initializing server
         copytree(cls.files.directory, cls.tmp)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,7 @@ from wsgiref.simple_server import make_server, WSGIRequestHandler
 import requests
 
 warnings.filterwarnings(action='ignore', category=DeprecationWarning,
-        module='requests')
+                        module='requests')
 
 
 TEST_FILE_PATH = os.path.join(os.path.dirname(__file__), 'test_files')
@@ -17,6 +17,7 @@ TEST_FILE_PATH = os.path.join(os.path.dirname(__file__), 'test_files')
 class SilentWSGIHandler(WSGIRequestHandler):
     def log_message(*args):
         pass
+
 
 class TestServer(object):
     """
@@ -27,7 +28,7 @@ class TestServer(object):
     def __init__(self, application):
         self.application = application
         self.server = make_server('127.0.0.1', 0, application,
-                handler_class=SilentWSGIHandler)
+                                  handler_class=SilentWSGIHandler)
 
     def get(self, *args, **kwargs):
         return self.request('get', *args, **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+  py27-lint,
   {py27,py34,py35,pypy}-django{18,19,master},
   py33-django18,
 
@@ -23,3 +24,7 @@ deps =
   django18: Django>=1.8,<1.9
   django19: Django>=1.9,<1.10
   djangomaster: https://github.com/django/django/archive/master.tar.gz
+
+[testenv:py27-lint]
+commands = flake8 --show-source
+deps = flake8==2.5.2

--- a/whitenoise/base.py
+++ b/whitenoise/base.py
@@ -8,8 +8,12 @@ import stat
 from wsgiref.headers import Headers
 
 
-class NotARegularFileError(Exception): pass
-class MissingFileError(NotARegularFileError): pass
+class NotARegularFileError(Exception):
+    pass
+
+
+class MissingFileError(NotARegularFileError):
+    pass
 
 
 def configure_mimetypes(extra_types):
@@ -21,7 +25,6 @@ def configure_mimetypes(extra_types):
     for content_type, extension in extra_types:
         mimetypes.add_type(content_type, extension)
     return mimetypes
-
 
 
 def stat_regular_file(path):
@@ -52,8 +55,8 @@ def format_prefix(prefix):
 class StaticFile(object):
 
     def __init__(self, path, headers, last_modified,
-            gzip_path=None,
-            gzip_headers=None):
+                 gzip_path=None,
+                 gzip_headers=None):
         self.path = path
         self.headers = headers
         self.last_modified = last_modified
@@ -218,8 +221,8 @@ class WhiteNoise(object):
             headers['Content-Encoding'] = encoding
 
     def get_charset(self, mimetype, path, url):
-        if (mimetype.startswith('text/')
-                or mimetype in self.MIMETYPES_WITH_CHARSET):
+        if (mimetype.startswith('text/') or
+                mimetype in self.MIMETYPES_WITH_CHARSET):
             return self.charset
 
     def add_cache_headers(self, headers, path, url):

--- a/whitenoise/django.py
+++ b/whitenoise/django.py
@@ -19,7 +19,7 @@ from django.utils.six.moves.urllib.parse import urlparse
 from .base import WhiteNoise, format_prefix
 # Import here under an alias for backwards compatibility
 from .storage import (CompressedManifestStaticFilesStorage as
-        GzipManifestStaticFilesStorage)
+                      GzipManifestStaticFilesStorage)
 
 
 __all__ = ['DjangoWhiteNoise', 'GzipManifestStaticFilesStorage']
@@ -65,13 +65,15 @@ class DjangoWhiteNoise(WhiteNoise):
     def check_settings(self, settings):
         if self.static_prefix == '/':
             static_url = getattr(settings, 'STATIC_URL', '').rstrip('/')
-            raise ImproperlyConfigured('STATIC_URL setting must include a '
-                    'path component, for example: STATIC_URL = {0!r}'.format(
-                        static_url + '/static/'))
+            raise ImproperlyConfigured(
+                'STATIC_URL setting must include a path component, for '
+                'example: STATIC_URL = {0!r}'.format(static_url + '/static/')
+            )
         if self.use_finders and not self.autorefresh:
-            raise ImproperlyConfigured('WHITENOISE_USE_FINDERS can only be '
-                    'enabled in development when WHITENOISE_AUTOREFRESH is '
-                    'also enabled.')
+            raise ImproperlyConfigured(
+                'WHITENOISE_USE_FINDERS can only be enabled in development '
+                'when WHITENOISE_AUTOREFRESH is also enabled.'
+            )
 
     def find_file(self, url):
         if self.use_finders and url.startswith(self.static_prefix):

--- a/whitenoise/gzip.py
+++ b/whitenoise/gzip.py
@@ -26,7 +26,9 @@ GZIP_EXCLUDE_EXTENSIONS = PrettyTuple((
     'woff', 'woff2'
 ))
 
-null_log = lambda x: x
+
+def null_log(s):
+    pass
 
 
 def main(root, extensions=None, quiet=False, log=print):

--- a/whitenoise/gzip.py
+++ b/whitenoise/gzip.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import, print_function, division, unicode_literals
 
 import argparse
-import contextlib
 import gzip
 import os
 import re
-import sys
 
 
 # Makes the default extension list look a bit nicer

--- a/whitenoise/gzip.py
+++ b/whitenoise/gzip.py
@@ -83,7 +83,9 @@ if __name__ == '__main__':
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('-q', '--quiet', help="Don't produce log output", action='store_true')
     parser.add_argument('root', help='Path root from which to search for files')
-    parser.add_argument('extensions', nargs='*', help='File extensions to exclude from gzipping',
-            default=GZIP_EXCLUDE_EXTENSIONS)
+    parser.add_argument('extensions',
+                        nargs='*',
+                        help='File extensions to exclude from gzipping',
+                        default=GZIP_EXCLUDE_EXTENSIONS)
     args = parser.parse_args()
     main(**vars(args))

--- a/whitenoise/storage.py
+++ b/whitenoise/storage.py
@@ -40,9 +40,8 @@ class CompressedStaticFilesMixin(object):
     @cached_property
     def excluded_extension_regex(self):
         extensions = getattr(settings, 'WHITENOISE_GZIP_EXCLUDE_EXTENSIONS',
-                GZIP_EXCLUDE_EXTENSIONS)
+                             GZIP_EXCLUDE_EXTENSIONS)
         return extension_regex(extensions)
-
 
 
 class HelpfulExceptionMixin(object):


### PR DESCRIPTION
flake8 is wrapper around pyflakes and pep8. Whilst some of the rules are slightly draconian, IMO running it adds more value than annoyance, and leads to a style that is consistent across projects.

This PR fixes the existing errors/warnings and then enables it on Travis :-)