### PR TITLE
Document HTTPS redirection & static asset pre-generation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Edit your ``settings.py`` file and add WhiteNoise to the top of your
 
 That's it, you're ready to go.
 
-Want forever-cachable files and gzip support? Just add this to your ``settings.py``:
+Want forever-cacheable files and gzip support? Just add this to your ``settings.py``:
 
 .. code-block:: python
 
@@ -131,7 +131,7 @@ your application, so it really doesn't make much difference how efficient
 WhiteNoise is.
 
 That said, WhiteNoise is pretty efficient. Because it only has to serve a fixed set of
-files it does all the work of finding files and determing the correct headers
+files it does all the work of finding files and determining the correct headers
 upfront on initialization. Requests can then be served with little more than a
 dictionary lookup to find the appropriate response. Also, when used with
 gunicorn (and most other WSGI servers) the actual business of pushing the file
@@ -160,7 +160,7 @@ The second problem with a push-based approach to handling static files is that
 it adds complexity and fragility to your deployment process: extra libraries
 specific to your storage backend, extra configuration and authentication keys,
 and extra tasks that must be run at specific points in the deployment in order
-for everythig to work.  With the CDN-as-caching-proxy approach that WhiteNoise
+for everything to work.  With the CDN-as-caching-proxy approach that WhiteNoise
 takes there are just two bits of configuration: your application needs the URL
 of the CDN, and the CDN needs the URL of your application. Everything else is
 just standard HTTP semantics. This makes your deployments simpler, your life

--- a/README.rst
+++ b/README.rst
@@ -39,12 +39,14 @@ Asked Questions`_ below.
 QuickStart for Django apps
 --------------------------
 
-Edit your ``settings.py`` file and add WhiteNoise to the top of your
-``MIDDLEWARE_CLASSES`` list:
+Edit your ``settings.py`` file and add WhiteNoise to the ``MIDDLEWARE_CLASSES``
+list, above all other middleware apart from Django's `SecurityMiddleware
+<https://docs.djangoproject.com/en/stable/ref/middleware/#module-django.middleware.security>`_:
 
 .. code-block:: python
 
    MIDDLEWARE_CLASSES = [
+     # 'django.middleware.security.SecurityMiddleware',
      'whitenoise.middleware.WhiteNoiseMiddleware',
      # ...
    ]

--- a/docs/base.rst
+++ b/docs/base.rst
@@ -80,7 +80,7 @@ files for you. Usage is simple:
       -q, --quiet  Don't produce log output (default: False)
 
 You can either run this during development and commit your compressed files to
-your repository, or you can run this as part of your build and deploy processs.
+your repository, or you can run this as part of your build and deploy processes.
 (Note that DjangoWhiteNoise handles this automatically, if you're using the
 custom storage backend.)
 
@@ -167,7 +167,7 @@ sub-classing WhiteNoise and setting the attributes directly.
     may have problems with fonts loading in Firefox, or accessing images in canvas
     elements, or other mysterious things.
 
-    The W3C `explicity state`__ that this behaviour is safe for publicly
+    The W3C `explicitly state`__ that this behaviour is safe for publicly
     accessible files.
 
 .. __: http://www.w3.org/TR/cors/#security

--- a/docs/base.rst
+++ b/docs/base.rst
@@ -119,6 +119,17 @@ apply here although obviously the exact method for generating the URLs for your 
 files will depend on the libraries you're using.
 
 
+Redirecting to HTTPS
+--------------------
+
+WhiteNoise does not handle redirection itself, but works well alongside
+`wsgi-sslify`_, which performs HTTP to HTTPS redirection as well as optionally
+setting an HSTS header. Simply wrap the WhiteNoise WSGI application with
+``sslify()`` - see the `wsgi-sslify`_ documentation for more details.
+
+.. _wsgi-sslify: https://github.com/jacobian/wsgi-sslify
+
+
 .. _configuration:
 
 Configuration attributes

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -237,7 +237,7 @@ arguments uppercased with a 'WHITENOISE\_' prefix.
     may have problems with fonts loading in Firefox, or accessing images in canvas
     elements, or other mysterious things.
 
-    The W3C `explicity state`__ that this behaviour is safe for publicly
+    The W3C `explicitly state`__ that this behaviour is safe for publicly
     accessible files.
 
 .. __: http://www.w3.org/TR/cors/#security

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -42,12 +42,14 @@ In Django 1.10 and later, you can use ``{% load static %}`` instead.
 2. Enable WhiteNoise
 --------------------
 
-Edit your ``settings.py`` file and add WhiteNoise to the top of your
-``MIDDLEWARE_CLASSES`` list:
+Edit your ``settings.py`` file and add WhiteNoise to the ``MIDDLEWARE_CLASSES``
+list, above all other middleware apart from Django's `SecurityMiddleware
+<https://docs.djangoproject.com/en/stable/ref/middleware/#module-django.middleware.security>`_:
 
 .. code-block:: python
 
    MIDDLEWARE_CLASSES = [
+     # 'django.middleware.security.SecurityMiddleware',
      'whitenoise.middleware.WhiteNoiseMiddleware',
      # ...
    ]

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -38,6 +38,16 @@ In Django 1.10 and later, you can use ``{% load static %}`` instead.
 
 .. _static: https://docs.djangoproject.com/en/1.9/ref/contrib/staticfiles/#std:templatetag-staticfiles-static
 
+.. note:: For performance and security reasons WhiteNoise does not check for new
+   files after startup (unless using Django `DEBUG` mode). As such, all static
+   files must be generated in advance. If you're using Django Compressor, this
+   can be performed using its `pre-compression`_ feature.
+
+   For the same reason, Django media files cannot be served by WhiteNoise, since
+   user-uploaded files won't exist at app startup.
+
+.. _pre-compression: https://django-compressor.readthedocs.org/en/latest/usage/#pre-compression
+
 
 2. Enable WhiteNoise
 --------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,7 +51,7 @@ Edit your ``settings.py`` file and add WhiteNoise to the top of your
 
 That's it, you're ready to go.
 
-Want forever-cachable files and gzip support? Just add this to your ``settings.py``:
+Want forever-cacheable files and gzip support? Just add this to your ``settings.py``:
 
 .. code-block:: python
 
@@ -131,7 +131,7 @@ your application, so it really doesn't make much difference how efficient
 WhiteNoise is.
 
 That said, WhiteNoise is pretty efficient. Because it only has to serve a fixed set of
-files it does all the work of finding files and determing the correct headers
+files it does all the work of finding files and determining the correct headers
 upfront on initialization. Requests can then be served with little more than a
 dictionary lookup to find the appropriate response. Also, when used with
 gunicorn (and most other WSGI servers) the actual business of pushing the file
@@ -160,7 +160,7 @@ The second problem with a push-based approach to handling static files is that
 it adds complexity and fragility to your deployment process: extra libraries
 specific to your storage backend, extra configuration and authentication keys,
 and extra tasks that must be run at specific points in the deployment in order
-for everythig to work.  With the CDN-as-caching-proxy approach that WhiteNoise
+for everything to work.  With the CDN-as-caching-proxy approach that WhiteNoise
 takes there are just two bits of configuration: your application needs the URL
 of the CDN, and the CDN needs the URL of your application. Everything else is
 just standard HTTP semantics. This makes your deployments simpler, your life

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,12 +39,14 @@ Asked Questions`_ below.
 QuickStart for Django apps
 --------------------------
 
-Edit your ``settings.py`` file and add WhiteNoise to the top of your
-``MIDDLEWARE_CLASSES`` list:
+Edit your ``settings.py`` file and add WhiteNoise to the ``MIDDLEWARE_CLASSES``
+list, above all other middleware apart from Django's `SecurityMiddleware
+<https://docs.djangoproject.com/en/stable/ref/middleware/#module-django.middleware.security>`_:
 
 .. code-block:: python
 
    MIDDLEWARE_CLASSES = [
+     # 'django.middleware.security.SecurityMiddleware',
      'whitenoise.middleware.WhiteNoiseMiddleware',
      # ...
    ]


### PR DESCRIPTION
* Recommend adding the Django middleware after SecurityMiddleware.
* Recommend wgsi-sslify for performing redirection to HTTPS. (Fixes #54)
* Explain the need for static assets to be generated in advance & why serving media files isn't supported. (Fixes #29)
* Fix spelling mistakes.

See individual commit messages for more details :-)