### PR TITLE
Add basic support for HTTP 1.1 Range requests (RFC 7233)

### DIFF
--- a/whitenoise/base.py
+++ b/whitenoise/base.py
@@ -111,7 +111,7 @@ class WhiteNoise(object):
             fileobj.seek(offset)
             if end == -1:
                 sbuffer.write(fileobj.read())
-                end = fileobj.tell()
+                end = fileobj.tell() - 1
             elif end >= offset:
                 sbuffer.write(fileobj.read(end - offset + 1))
             else:


### PR DESCRIPTION
Add basic support for HTTP 1.1 Range requests (RFC 7233: https://tools.ietf.org/html/rfc7233).

Modify whitenoise.base.Whitenoise.serve() to handle Range requests.
The modification has been validated with Python 2.7 and Django 1.9 by streaming a "static" video file (MP4) to an iOS device (iPhone 6, iOS 9.3.1). Safari would refuse to play the video if it was not streamed to the device using Range requests and "Partial Content" responses.
