### PR TITLE
Set Adobe's preferred crossdomain.xml Content-Type

### DIFF
--- a/whitenoise/media_types.py
+++ b/whitenoise/media_types.py
@@ -121,5 +121,7 @@ def default_types():
         '.xpi': 'application/x-xpinstall',
         '.xspf': 'application/xspf+xml',
         '.zip': 'application/zip',
-        'apple-app-site-association': 'application/pkc7-mime'
+        'apple-app-site-association': 'application/pkc7-mime',
+        # Adobe Products - see https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/xdomain.html#policy-file-host-basics
+        'crossdomain.xml': 'text/x-cross-domain-policy',        
     }


### PR DESCRIPTION
This is pedantic but matches the preferred value at https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/xdomain.html#policy-file-host-basics and what's sent in the wild by https://www.adobe.com/crossdomain.xml