### PR TITLE
Test against Django 1.11 and Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,14 @@ env:
     - DJANGO_VERSION='Django>=1.8,<1.9'
     - DJANGO_VERSION='Django>=1.9,<1.10'
     - DJANGO_VERSION='Django>=1.10,<1.11'
-    - DJANGO_VERSION=https://github.com/django/django/archive/master.tar.gz
+    - DJANGO_VERSION='Django>=1.11a1,<2.0'
 matrix:
   include:
     - python: 3.3
       env: DJANGO_VERSION='Django>=1.8,<1.9'
+    # Django 2.0 only supports Python 3.5+.
+    - python: 3.5
+      env: DJANGO_VERSION=https://github.com/django/django/archive/master.tar.gz
     - python: 2.7
       env: lint
       install: travis_retry pip install flake8==3.0.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,13 @@ matrix:
   include:
     - python: 3.3
       env: DJANGO_VERSION='Django>=1.8,<1.9'
+    # Python 3.6 is only officially supported by Django 1.11+.
+    - python: 3.6
+      env: DJANGO_VERSION='Django>=1.11a1,<2.0'
     # Django 2.0 only supports Python 3.5+.
     - python: 3.5
+      env: DJANGO_VERSION=https://github.com/django/django/archive/master.tar.gz
+    - python: 3.6
       env: DJANGO_VERSION=https://github.com/django/django/archive/master.tar.gz
     - python: 2.7
       env: lint

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
   py27-lint,
-  {py27,py34,py35,pypy}-django{18,19,110,master},
+  py{27,34,35,py}-django{18,19,110,111},
   py33-django18,
+  py35-master,
 
 [testenv]
 basepython =
@@ -24,6 +25,7 @@ deps =
   django18: Django>=1.8,<1.9
   django19: Django>=1.9,<1.10
   django110: Django>=1.10,<1.11
+  django111: Django>=1.11a1,<2.0
   djangomaster: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:py27-lint]

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist =
   py27-lint,
   py{27,34,35,py}-django{18,19,110,111},
   py33-django18,
-  py35-master,
+  py36-django111,
+  py{35,36}-master,
 
 [testenv]
 basepython =
@@ -11,6 +12,7 @@ basepython =
   py33: python3.3
   py34: python3.4
   py35: python3.5
+  py36: python3.6
   pypy: pypy
 commands =
   coverage run --branch --include=whitenoise/* -m unittest discover


### PR DESCRIPTION
**1) Test against Django 1.11a1+ and stop testing master on Python 2.x**
Django 1.11a1 has been released:
https://www.djangoproject.com/weblog/2017/jan/17/django-111-alpha-1/

Django 2.0 has dropped support for Python <3.5 (though may re-add 3.4
support later in the release cycle, but isn't supporting it for now):
https://docs.djangoproject.com/en/dev/releases/2.0/#python-compatibility

**2) Test Django 1.11/master against Python 3.6**
Django 1.11 is the first version to officially support Python 3.6:
https://docs.djangoproject.com/en/1.11/faq/install/#what-python-version-can-i-use-with-django