### PR TITLE
Drop _CLASSES from MIDDLEWARE in docs.

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -44,13 +44,14 @@ In Django 1.10 and later, you can use ``{% load static %}`` instead.
 2. Enable WhiteNoise
 --------------------
 
-Edit your ``settings.py`` file and add WhiteNoise to the ``MIDDLEWARE_CLASSES``
-list. The WhiteNoise middleware should be placed directly after the Django `SecurityMiddleware
-<https://docs.djangoproject.com/en/stable/ref/middleware/#module-django.middleware.security>`_ and before all other middleware:
+Edit your ``settings.py`` file and add WhiteNoise to the ``MIDDLEWARE`` list. 
+The WhiteNoise middleware should be placed directly after the Django `SecurityMiddleware
+<https://docs.djangoproject.com/en/stable/ref/middleware/#module-django.middleware.security>`_ 
+and before all other middleware:
 
 .. code-block:: python
 
-   MIDDLEWARE_CLASSES = [
+   MIDDLEWARE = [
      'django.middleware.security.SecurityMiddleware',
      'whitenoise.middleware.WhiteNoiseMiddleware',
      # ...

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,7 +47,7 @@ list, above all other middleware apart from Django's `SecurityMiddleware
 
 .. code-block:: python
 
-   MIDDLEWARE_CLASSES = [
+   MIDDLEWARE = [
      # 'django.middleware.security.SecurityMiddleware',
      'whitenoise.middleware.WhiteNoiseMiddleware',
      # ...


### PR DESCRIPTION
As of Django 1.10 the usage of the MIDDLEWARE_CLASSES setting is
deprecated in favor for MIDDLEWARE. Whitenoise is already compatible
with both versions but the documentation did not reflect that change.