### PR TITLE
Refactor Process Request for Easier Override

### DIFF
--- a/whitenoise/middleware.py
+++ b/whitenoise/middleware.py
@@ -26,12 +26,16 @@ class WhiteNoiseMiddleware(DjangoWhiteNoise):
         return response
 
     def process_request(self, request):
+        path_info = self.process_path_info(request.path_info)
         if self.autorefresh:
-            static_file = self.find_file(request.path_info)
+            static_file = self.find_file(path_info)
         else:
-            static_file = self.files.get(request.path_info)
+            static_file = self.files.get(path_info)
         if static_file is not None:
             return self.serve(static_file, request)
+
+    def process_path_info(self, path_info):
+        return path_info
 
     def serve(self, static_file, request):
         response = static_file.get_response(request.method, request.META)


### PR DESCRIPTION
It'd be nice if there was a method to override to easily change request's path_info.

We want to serve /static/docs/integration/index.html file when url path is /integration/. To do that we subclass WhiteNoiseMiddleware and override process_request. However, it would be better if we could override another method with less logic. 
Basically we want 
```
return self.files.get(request.path_info)
```
to become
```
path_info = request.path_info
if path_info == '/integration/':
    path_info = '/static/docs/integration/index.html'
return self.files.get(path_info)
```

With this PR we can write 
```
def process_path_info(self, path_info):
    if path_info == '/integration/':
        return '/static/docs/integration/index.html'
    else:
        return path_info
```
in our subclass of WhiteNoiseMiddleware

