### PR TITLE
Document installation process

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,14 @@ Worried that serving static files with Python is horribly inefficient?
 Still think you should be using Amazon S3? Have a look at the `Infrequently
 Asked Questions`_ below.
 
+Installation
+------------
+
+Install with:
+
+.. code-block:: sh
+
+    pip install whitenoise
 
 QuickStart for Django apps
 --------------------------


### PR DESCRIPTION
I set up whitenoise on a project again yesterday and scanned the docs looking for a `pip install` to run. I couldn't remember if it really was called `whitenoise` on PyPI, or `django-whitenoise`, or something else, and wanted to check. Best to be explicit about it.