### PR TITLE
Add 'Framework :: Django :: 1.11' trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,7 @@ setup(
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
-        # Temporarily removed pending resolution of
-        # https://github.com/pypa/warehouse/issues/1673
-        # 'Framework :: Django :: 1.11',
+        'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
The 'Framework :: Django :: 1.11' trove classifier is now available. "https://github.com/pypa/warehouse/issues/1673"