### PR TITLE
Add .xz and .br to SKIP_COMPRESS_EXTENSIONS

### DIFF
--- a/whitenoise/compress.py
+++ b/whitenoise/compress.py
@@ -22,7 +22,7 @@ class Compressor(object):
         # Images
         'jpg', 'jpeg', 'png', 'gif', 'webp',
         # Compressed files
-        'zip', 'gz', 'tgz', 'bz2', 'tbz',
+        'zip', 'gz', 'tgz', 'bz2', 'tbz', 'xz', 'br',
         # Flash
         'swf', 'flv',
         # Fonts


### PR DESCRIPTION
This reduces the time wasted trying to compress these uncompressible files, which can be significant if re-running compression against a directory where .br files have previously been generated.