### PR TITLE
Demonstration of ASGI support.

### DIFF
--- a/whitenoise/__init__.py
+++ b/whitenoise/__init__.py
@@ -1,5 +1,5 @@
-from .base import WhiteNoise
+from .base import WhiteNoise, ASGIWhiteNoise
 
 __version__ = '4.0b4'
 
-__all__ = ['WhiteNoise']
+__all__ = ['WhiteNoise', 'ASGIWhiteNoise']

--- a/whitenoise/base.py
+++ b/whitenoise/base.py
@@ -274,7 +274,7 @@ class ASGISession():
         response = await self.static_file.get_response_async(self.scope['method'], self.headers)
         await send({
             'type': 'http.response.start',
-            'status': response.status,
+            'status': response.status.value,
             'headers': [
                 (key.lower().encode(), value.encode())
                 for key, value in response.headers

--- a/whitenoise/base.py
+++ b/whitenoise/base.py
@@ -286,13 +286,13 @@ class ASGISession():
                 'body': b''
             })
         else:
-            await send({
-                'type': 'http.response.body',
-                'body': await response.file.read(),
-            })
-            # async for chunk in response.file.read(8192):
-            #     await send({
-            #         'type': 'http.response.body',
-            #         'body': chunk,
-            #         'more_body': bool(chunk)
-            #     })
+            while True:
+                chunk = await response.file.read(8192)
+                more_body = bool(chunk)
+                await send({
+                    'type': 'http.response.body',
+                    'body': chunk,
+                    'more_body': more_body
+                })
+                if not more_body:
+                    break


### PR DESCRIPTION
This pull request is intended as a demonstration of the scope of changes needed to add ASGI support to WhiteNoise.

Some notes:

* Uses `async` and `await` syntax. The codebase won't be 2.7 compatible.
* Requires the `aiofiles` package for non-blocking file open and read.
* Does not implement `sendfile` support. There's not yet any provision for that in the ASGI spec, so there'd need to be some discussion around the right API for adding that as an extension.

An example...

**example.py**

```python
from whitenoise import ASGIWhiteNoise

class MyASGIApp():
    def __init__(self, scope):
        self.scope = scope

    async def __call__(self, receive, send):
        await send({
            'type': 'http.response.start',
            'status': 200,
            'headers': [
                [b'content-type', b'text/plain'],
                [b'content-length', b'13'],
            ],
        })
        await send({
            'type': 'http.response.body',
            'body': b'Hello, world!',
        })


app = ASGIWhiteNoise(MyASGIApp, root='static', prefix='static')
```

Run using `daphne`...

```bash
$ daphne -b 127.0.0.1 -p 8001 example:app
```