### PR TITLE
Remove usage of Django's FILE_CHARSET setting

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -317,7 +317,7 @@ arguments upper-cased with a 'WHITENOISE\_' prefix.
 
 .. attribute:: WHITENOISE_CHARSET
 
-    :default: ``settings.FILE_CHARSET`` (utf-8)
+    :default: ``'utf-8'``
 
     Charset to add as part of the ``Content-Type`` header for all files whose
     mimetype allows a charset.

--- a/whitenoise/middleware.py
+++ b/whitenoise/middleware.py
@@ -70,7 +70,6 @@ class WhiteNoiseMiddleware(WhiteNoise):
 
     def configure_from_settings(self, settings):
         # Default configuration
-        self.charset = settings.FILE_CHARSET
         self.autorefresh = settings.DEBUG
         self.use_finders = settings.DEBUG
         self.static_prefix = urlparse(settings.STATIC_URL or '').path


### PR DESCRIPTION
The setting is [deprecated in Django 2.2](https://github.com/django/django/pull/10472).