### PR TITLE
Fix HTTP 304 handling when both ETag and last modified specified

### DIFF
--- a/tests/test_whitenoise.py
+++ b/tests/test_whitenoise.py
@@ -102,6 +102,18 @@ class WhiteNoiseTest(TestCase):
         response = self.server.get(self.files.js_url, headers={'If-None-Match': etag})
         self.assertEqual(response.status_code, 200)
 
+    def test_etag_overrules_modified_since(self):
+        """
+        Browsers send both headers so it's important that the ETag takes precedence
+        over the last modified time, so that deploy-rollbacks are handled correctly.
+        """
+        headers = {
+            'If-None-Match': '"594bd1d1-36"',
+            'If-Modified-Since': 'Fri, 11 Apr 2100 11:47:06 GMT',
+        }
+        response = self.server.get(self.files.js_url, headers=headers)
+        self.assertEqual(response.status_code, 200)
+
     def test_max_age(self):
         response = self.server.get(self.files.js_url)
         self.assertEqual(response.headers['Cache-Control'], 'max-age=1000, public')

--- a/whitenoise/responders.py
+++ b/whitenoise/responders.py
@@ -167,8 +167,9 @@ class StaticFile(object):
         return alternatives
 
     def is_not_modified(self, request_headers):
-        if self.etag == request_headers.get('HTTP_IF_NONE_MATCH'):
-            return True
+        previous_etag = request_headers.get('HTTP_IF_NONE_MATCH')
+        if previous_etag is not None:
+            return previous_etag == self.etag
         try:
             last_requested = request_headers['HTTP_IF_MODIFIED_SINCE']
         except KeyError:


### PR DESCRIPTION
Previously if the ETag specified in the `If-None-Match` header differed from the file's ETag, but the last modified time in the `If-Modified-Since` header was newer than the file modified time, then an HTTP 304 would be returned rather than the expected HTTP 200.

This case can occur when a deployment is rolled back, and User Agents make a request with the reverted content's ETag and newer last modified time. (Browsers typically send both headers.)

Fixes #202.