### PR TITLE
Add mimetype for webassembly

### DIFF
--- a/whitenoise/media_types.py
+++ b/whitenoise/media_types.py
@@ -105,6 +105,7 @@ def default_types():
         '.tk': 'application/x-tcl',
         '.ts': 'video/mp2t',
         '.txt': 'text/plain',
+        '.wasm': 'application/wasm',
         '.war': 'application/java-archive',
         '.wbmp': 'image/vnd.wap.wbmp',
         '.webm': 'video/webm',


### PR DESCRIPTION
This adds a media type for webassembly modules.

According to this part of the [WebAssembly standard](https://www.w3.org/TR/wasm-web-api-1/#streaming-modules), web browsers must reject the compilation of webassembly modules that don't have the correct mimetype, so it's pretty critical for applications serving .wasm.