### PR TITLE
Remove django.utils.six import (removed in django 3.0)

### DIFF
--- a/whitenoise/middleware.py
+++ b/whitenoise/middleware.py
@@ -7,7 +7,10 @@ from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.contrib.staticfiles import finders
 from django.http import FileResponse
-from django.utils.six.moves.urllib.parse import urlparse
+try:
+    from urllib.parse import urlparse  # PY3
+except ImportError:
+    from urlparse import urlparse  # PY2
 
 from .base import WhiteNoise
 from .string_utils import decode_if_byte_string, ensure_leading_trailing_slash


### PR DESCRIPTION
Django 3.0 remove django.utils.six, so do a raw import.