### PR TITLE
Add tests for compress.py and ignore main blocks from coverage.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,7 @@ universal = 1
 max-line-length = 100
 # See https://github.com/PyCQA/pycodestyle/issues/373
 ignore = E203
+
+[coverage:report]
+exclude_lines =
+    if __name__ == .__main__.:


### PR DESCRIPTION
This takes `compress.py` coverage up to 95% and total coverage to 90%.

If it's not desirable feel free to reject - it's definitely quite different from the other tests (most tests seem to be more integration style whereas these are definitely more unit test style).

I've added some config to ignore main blocks, which is normally pretty acceptable (and a bit cheeky for the coverage of `compress.py`...).

Wondering if there is a simple way to mock imports to raise an importerror without messing with the internal import lib - a lot of other files could do with this for testing.