### PR TITLE
Add python_requires to leverage pypi search

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,5 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     extras_require={"brotli": ["Brotli"]},
-    python_requires='>=3.5, <4',
+    python_requires=">=3.5, <4",
 )

--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,5 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     extras_require={"brotli": ["Brotli"]},
+    python_requires='>=3.5, <4',
 )


### PR DESCRIPTION
Installing `whitenoise` in a py27 project (I know it'll be deprecated, :disappointed: ) made me install an unsupported version, the `5`.
In order to avoid such behaviour it's advisable to specify the python version required by the build in the setup.py file.
https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires