### PR TITLE
Add CloudFront docs to serve pre-compressed gzip and brotli content

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -177,6 +177,20 @@ For apps on Heroku, you'd run this command
     search results.  You can restrict CloudFront to only proxy your static
     files by following :ref:`these directions <restricting-cloudfront>`.
 
+.. using compression algorithms other than gzip::
+
+    By default, CloudFront will discard any ``Accept-Encoding`` header browsers include
+    in requests, unless the value of the header is gzip. If it is gzip, CloudFront will
+    fetch the uncompressed file from the origin, compress it, and return it to the
+    requesting browser.
+
+    To get CloudFront to not do the compression itself as well as serve files compressed
+    using other algorithms, such as Brotli, you must configure your distribution to
+    `cache based on the Accept-Encoding header`__. You can do this in the ``Behaviours``
+    tab of your distribution.
+
+.. __: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html#compressed-content-custom-origin
+
 
 .. _runserver-nostatic:
 


### PR DESCRIPTION
Hey there @evansd!

I followed your instructions for Django/CloudFront and enabled Brotli support. I noticed that with more or less default distribution settings, Brotli files were not being served, despite my browser requesting with accept-encoding: gzip, deflate, br and the Brotli encodings having been properly generated by collectstatic.

I dug in a little more, and read that by default a CloudFront distribution will disregard accept-encoding headers other than gzip. Also, that CloudFront itself will attempt to fetch uncompressed files from the configured origin and compress them (only using gzip) itself. It actually modifies the accept-encoding header before passing it along to the origin.

To get the distribution to serve the files generated using `collectstatic` and to not mangle the accept-encoding header before passing it to the origin, you have to [cache based on the accept-encoding header](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html#compressed-content-custom-origin).

Once I did this, Brotli files were served up nicely via CloudFront and cached there as expected.

For this reason I thought it'd be good to buff up the docs on setting up Amazon CloudFront for use with Whitenoise - this PR makes a start on that.

Am I missing anything? :) I'm not particularly experienced with CloudFront and caching, so very curious to hear if this all checks out from your perspective. If it does, happy to iterate on these docs changes until you're content with them.

Thanks!