### PR TITLE
Add markdown to media_types

### DIFF
--- a/whitenoise/media_types.py
+++ b/whitenoise/media_types.py
@@ -66,6 +66,7 @@ def default_types():
         ".m3u8": "application/vnd.apple.mpegurl",
         ".m4a": "audio/x-m4a",
         ".m4v": "video/x-m4v",
+        ".md": "text/markdown",
         ".mid": "audio/midi",
         ".midi": "audio/midi",
         ".mjs": "text/javascript",


### PR DESCRIPTION
Per [RFC 7763](https://tools.ietf.org/html/rfc7763) "The text/markdown Media Type".

Used by many frameworks, often compiled to html before serving to clients but not always.