### PR TITLE
Add webp support for when a webp version of an image is available (with fallback for older browsers and CDN support).

### DIFF
--- a/whitenoise/middleware.py
+++ b/whitenoise/middleware.py
@@ -152,7 +152,7 @@ class WhiteNoiseMiddleware(WhiteNoise):
                 # If the static_url function maps the name without hash
                 # back to the original name, then we know we've got a
                 # versioned filename
-                if static_url and basename(static_url) == basename(url):
+                if static_url and basename(os.path.splitext(static_url)[0]) == basename(os.path.splitext(url)[0]):
                     return True
 
         static_url = self.get_static_url(name_without_hash)

--- a/whitenoise/middleware.py
+++ b/whitenoise/middleware.py
@@ -138,10 +138,23 @@ class WhiteNoiseMiddleware(WhiteNoise):
         """
         if not url.startswith(self.static_prefix):
             return False
-        name = url[len(self.static_prefix) :]
+        name = url[len(self.static_prefix):]
+
         name_without_hash = self.get_name_without_hash(name)
         if name == name_without_hash:
             return False
+
+        filename, ext = os.path.splitext(name_without_hash)
+        if ext == '.webp':
+            # If hash is correct for any of the other files, assume it is correct.
+            for img_ext in FILE_FORMATS_WITH_WEBP_SUBSTITION:
+                static_url = self.get_static_url(filename + img_ext)
+                # If the static_url function maps the name without hash
+                # back to the original name, then we know we've got a
+                # versioned filename
+                if static_url and basename(static_url) == basename(url):
+                    return True
+
         static_url = self.get_static_url(name_without_hash)
         # If the static_url function maps the name without hash
         # back to the original name, then we know we've got a

--- a/whitenoise/middleware.py
+++ b/whitenoise/middleware.py
@@ -200,7 +200,7 @@ class WebPWhiteNoiseMiddleware(WhiteNoiseMiddleware):
             filename, ext = os.path.splitext(request.path_info)
 
             if ext in FILE_FORMATS_WITH_WEBP_SUBSTITION:
-                if 'image/webp' in request.headers.get('Accept'):
+                if 'image/webp' in request.headers.get('Accept', ''):
                     if self.autorefresh:
                         webp_static_file = self.find_file(filename + '.webp')
                     else:


### PR DESCRIPTION
Added a webp whitenoise middleware. It checks whether a webp version of an image is available and then serves that instead of the image itself. Also include the "Vary: Accept" header for CDNs.