### PR TITLE
Added Django Middleware that Delays Traversal of Static Root until Requested

### DIFF
--- a/whitenoise/base.py
+++ b/whitenoise/base.py
@@ -96,18 +96,31 @@ class WhiteNoise(object):
             return file_wrapper(response.file)
         else:
             return []
+    
+    def normalize_root(self, root):
+        value = decode_if_byte_string(root, force_text=True)
+        value = os.path.abspath(value)
+        value = value.rstrip(os.path.sep) + os.path.sep
+        return value
+    
+    def normalize_prefix(self, prefix):
+        value = decode_if_byte_string(prefix)
+        value = ensure_leading_trailing_slash(value)
+        return value
+    
+    def insert_directory(self, root, prefix):
+        root = self.normalize_root(root)
+        prefix = self.normalize_prefix(prefix)
+        self.directories.insert(0, (root, prefix))
 
     def add_files(self, root, prefix=None):
-        root = decode_if_byte_string(root, force_text=True)
-        root = os.path.abspath(root)
-        root = root.rstrip(os.path.sep) + os.path.sep
-        prefix = decode_if_byte_string(prefix)
-        prefix = ensure_leading_trailing_slash(prefix)
+        root = self.normalize_root(root)
+        prefix = self.normalize_prefix(prefix)
         if self.autorefresh:
             # Later calls to `add_files` overwrite earlier ones, hence we need
             # to store the list of directories in reverse order so later ones
             # match first when they're checked in "autorefresh" mode
-            self.directories.insert(0, (root, prefix))
+            self.insert_directory(root, prefix)
         else:
             if os.path.isdir(root):
                 self.update_files_dictionary(root, prefix)

--- a/whitenoise/middleware.py
+++ b/whitenoise/middleware.py
@@ -18,7 +18,6 @@ from .string_utils import decode_if_byte_string, ensure_leading_trailing_slash
 __all__ = [
     "WhiteNoiseMiddleware",
     "LazyWhiteNoiseMiddleware",
-    "LazyManifestWhiteNoiseMiddleware",
 ]
 
 

--- a/whitenoise/middleware.py
+++ b/whitenoise/middleware.py
@@ -205,5 +205,5 @@ class LazyWhiteNoiseMiddleware(WhiteNoiseMiddleware):
             )])
 
     def can_lazy_load_url(self, url):
-        return super().can_lazy_load_url(url) and \
+        return url.startswith(self.static_prefix) and \
             self.known_static_urls is None or url in self.known_static_urls

--- a/whitenoise/middleware.py
+++ b/whitenoise/middleware.py
@@ -71,7 +71,6 @@ class WhiteNoiseMiddleware(WhiteNoise):
         return response
 
     def process_request(self, request):
-        response = None
         if self.autorefresh:
             static_file = self.find_file(request.path_info)
         else:
@@ -82,8 +81,7 @@ class WhiteNoiseMiddleware(WhiteNoise):
                     logger.info('Lazy loaded %s', request.path_info)
                     self.files[request.path_info] = static_file
         if static_file is not None:
-            response = self.serve(static_file, request)
-        return response
+            return self.serve(static_file, request)
 
     @staticmethod
     def serve(static_file, request):

--- a/whitenoise/middleware.py
+++ b/whitenoise/middleware.py
@@ -13,7 +13,7 @@ from .base import WhiteNoise
 from .string_utils import decode_if_byte_string, ensure_leading_trailing_slash
 
 
-__all__ = ["WhiteNoiseMiddleware"]
+__all__ = ["WhiteNoiseMiddleware", "LazyWhiteNoiseMiddleware"]
 
 
 logger = logging.getLogger(__name__)

--- a/whitenoise/middleware.py
+++ b/whitenoise/middleware.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from posixpath import basename
 from urllib.parse import urlparse
@@ -13,6 +14,9 @@ from .string_utils import decode_if_byte_string, ensure_leading_trailing_slash
 
 
 __all__ = ["WhiteNoiseMiddleware"]
+
+
+logger = logging.getLogger(__name__)
 
 
 class WhiteNoiseFileResponse(FileResponse):
@@ -72,6 +76,7 @@ class WhiteNoiseMiddleware(WhiteNoise):
             if static_file is None and self.can_lazy_load_url(request.path_info):
                 static_file = self.find_file(request.path_info)
                 if static_file is not None:
+                    logger.info('Lazy loaded %s', request.path_info)
                     self.files[request.path_info] = static_file
         if static_file is not None:
             response = self.serve(static_file, request)

--- a/whitenoise/middleware.py
+++ b/whitenoise/middleware.py
@@ -195,11 +195,6 @@ class WhiteNoiseMiddleware(WhiteNoise):
 class LazyWhiteNoiseMiddleware(WhiteNoiseMiddleware):
     add_static_root_files = False
 
-    def can_lazy_load_url(self, url):
-        return url.startswith(self.static_prefix)
-
-
-class LazyManifestWhiteNoiseMiddleware(LazyWhiteNoiseMiddleware):
     @cached_property
     def known_static_urls(self):
         if isinstance(staticfiles_storage, ManifestStaticFilesStorage):

--- a/whitenoise/middleware.py
+++ b/whitenoise/middleware.py
@@ -51,8 +51,11 @@ class WhiteNoiseMiddleware(WhiteNoise):
         self.configure_from_settings(settings)
         # Pass None for `application`
         super(WhiteNoiseMiddleware, self).__init__(None)
-        if self.add_static_root_files and self.static_root:
-            self.add_files(self.static_root, prefix=self.static_prefix)
+        if self.static_root:
+            if self.add_static_root_files:
+                self.add_files(self.static_root, prefix=self.static_prefix)
+            else:
+                self.insert_directory(self.static_root, self.static_prefix)
         if self.root:
             self.add_files(self.root)
         if self.use_finders and not self.autorefresh:

--- a/whitenoise/middleware.py
+++ b/whitenoise/middleware.py
@@ -202,9 +202,10 @@ class LazyWhiteNoiseMiddleware(WhiteNoiseMiddleware):
 class LazyManifestWhiteNoiseMiddleware(LazyWhiteNoiseMiddleware):
     @cached_property
     def known_static_urls(self):
+        serve_unhashed = not getattr(settings, "WHITENOISE_KEEP_ONLY_HASHED_FILES", False)
         return set(['{}{}'.format(self.static_prefix, n) for n in chain(
-            staticfiles_storage.hashed_files.keys(),
             staticfiles_storage.hashed_files.values(),
+            staticfiles_storage.hashed_files.keys() if serve_unhashed else [],
         )])
 
     def can_lazy_load_url(self, url):


### PR DESCRIPTION
Added an additional middleware for Django users that avoids the problems described #263 by constructing the file cache as it is requested.  The middleware makes use of the `WHITENOISE_KEEP_ONLY_HASHED_FILES` setting to determine if it should serve unhashed files.  And it makes use of `staticfiles_storage.hashed_files` if the static storage is a subclass of `ManifestStaticFilesStorage` to know which files are supposed to exist to avoid hitting the disk when not required.