### PR TITLE
Added support for Django 3.2

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -117,7 +117,7 @@ Compatibility
 WhiteNoise works with any WSGI-compatible application and is tested on Python
 **3.5** – **3.8** and **PyPy**, on both Linux and Windows.
 
-Django WhiteNoiseMiddlware is tested with Django versions **1.11** --- **3.1**
+Django WhiteNoiseMiddlware is tested with Django versions **1.11** --- **3.2**
 
 
 Endorsements

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.0",
         "Framework :: Django :: 3.1",
+        "Framework :: Django :: 3.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
   django22: Django>=2.2,<3.0
   django30: Django>=3.0,<3.1
   django31: Django>=3.1,<3.2
+  django32: Django>=3.2,<3.3
   master: https://github.com/django/django/archive/master.tar.gz
 extras =
   brotli


### PR DESCRIPTION
Django 3.2 now has a release candidate and is expected to land early April.

I am not intimately familiar with the inner workings of `whitenoise` and cannot say if there are any unforeseen compatibility issues. However, my initial tests were positive.

Here is the working list of [backwards incompatible changes](https://docs.djangoproject.com/en/3.2/releases/3.2/#backwards-incompatible-changes-in-3-2).