### PR TITLE
Ignore unparsable If-Modified-Since headers and return the file

### DIFF
--- a/tests/test_whitenoise.py
+++ b/tests/test_whitenoise.py
@@ -117,6 +117,10 @@ def test_modified(server, files):
     response = server.get(files.js_url, headers={"If-Modified-Since": last_mod})
     assert response.status_code == 200
 
+def test_modified_mangled_date_firefox_91_0b3(server, files):
+    last_mod = "Fri, 16 Jul 2021 09:09:1626426577S GMT"
+    response = server.get(files.js_url, headers={"If-Modified-Since": last_mod})
+    assert response.status_code == 200
 
 def test_etag_matches(server, files):
     response = server.get(files.js_url)

--- a/whitenoise/responders.py
+++ b/whitenoise/responders.py
@@ -182,7 +182,10 @@ class StaticFile(object):
             last_requested = request_headers["HTTP_IF_MODIFIED_SINCE"]
         except KeyError:
             return False
-        return parsedate(last_requested) >= self.last_modified
+        last_requested_ts = parsedate(last_requested)
+        if last_requested_ts is not None:
+            return parsedate(last_requested) >= self.last_modified
+        return False
 
     def get_path_and_headers(self, request_headers):
         accept_encoding = request_headers.get("HTTP_ACCEPT_ENCODING", "")


### PR DESCRIPTION
Firefox 91 mangling the If-Modified-Since request header with a
(perhaps) fractional second?