### PR TITLE
Adjust test_get_gzip to set Accept-Encoding header

### DIFF
--- a/tests/test_django_whitenoise.py
+++ b/tests/test_django_whitenoise.py
@@ -98,7 +98,7 @@ def test_unversioned_file_not_cached_forever(server, static_files, _collect_stat
 
 def test_get_gzip(server, static_files, _collect_static):
     url = storage.staticfiles_storage.url(static_files.js_path)
-    response = server.get(url)
+    response = server.get(url, headers={"Accept-Encoding": "gzip"})
     assert response.content == static_files.js_content
     assert response.headers["Content-Encoding"] == "gzip"
     assert response.headers["Vary"] == "Accept-Encoding"


### PR DESCRIPTION
requests 2.26.0 added brotli support and now gets its Accept-Encoding
header from urllib3.util.make_headers. The latter appends ",br" to it
if the brotli or brotlicffi packages are installed, thus breaking the
test_django_whitenoise.py::test_get_gzip test.

Adjust test_get_gzip to explicitly set "Accept-Encoding" to "gzip".