### PR TITLE
Improve Flake8 configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,9 +2,10 @@
 universal = 1
 
 [flake8]
-max-line-length = 100
-# See https://github.com/PyCQA/pycodestyle/issues/373
-ignore = E203
+max-line-length = 88
+extend-ignore = E203
+per-file-ignores =
+    whitenoise/media_types.py:E501
 
 [coverage:run]
 branch = True

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -46,7 +46,9 @@ def _compressed_storage(setup):
 def _compressed_manifest_storage(setup):
     with override_settings(
         **{
-            "STATICFILES_STORAGE": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+            "STATICFILES_STORAGE": (
+                "whitenoise.storage.CompressedManifestStaticFilesStorage"
+            ),
             "WHITENOISE_KEEP_ONLY_HASHED_FILES": True,
         }
     ):


### PR DESCRIPTION
Use exactly the Black-compatible config from: https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8

Ignore E501 in media_types.py which is generated.