### PR TITLE
Remove pytest config DJANGO_SETTINGS_MODULE

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,3 @@ source =
 
 [coverage:report]
 show_missing = True
-
-[tool:pytest]
-DJANGO_SETTINGS_MODULE = tests.django_settings


### PR DESCRIPTION
Prevent this warning:

```
PytestConfigWarning: Unknown config ini key: DJANGO_SETTINGS_MODULE
```

The config key maybe came from an attempt to use pytest-django, but it was never used.