### PR TITLE
Remove mention of testing on PyPy since untrue

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -115,7 +115,7 @@ Compatibility
 -------------
 
 WhiteNoise works with any WSGI-compatible application and is tested on Python
-**3.5** – **3.8** and **PyPy**, on both Linux and Windows.
+**3.5** – **3.8**, on both Linux and Windows.
 
 Django WhiteNoiseMiddlware is tested with Django versions **2.1** --- **3.2**
 


### PR DESCRIPTION
Looks like the last mention of PyPy was removed in 80a8f8000769502d28e57b1ec2877dedc91d0b39 