### PR TITLE
Treat "Accept-Encoding: *" as not accepting any encoding

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,10 @@ Pending
 
   Thanks to Richard Tibbles in `PR #322 <https://github.com/evansd/whitenoise/pull/322>`__.
 
+* Treat empty and ``"*"`` values for ``Accept-Encoding`` as if the client doesn’t support any encoding.
+
+  Thanks to Richard Tibbles in `PR #323 <https://github.com/evansd/whitenoise/pull/323>`__.
+
 v5.3.0
 ------
 * Gracefully handle unparsable If-Modified-Since headers (thanks

--- a/tests/test_whitenoise.py
+++ b/tests/test_whitenoise.py
@@ -89,6 +89,20 @@ def test_get_not_accept_gzip(server, files):
     assert response.headers["Vary"] == "Accept-Encoding"
 
 
+def test_get_accept_star(server, files):
+    response = server.get(files.gzip_url, headers={"Accept-Encoding": "*"})
+    assert response.content == files.gzip_content
+    assert response.headers["Content-Encoding"] == "gzip"
+    assert response.headers["Vary"] == "Accept-Encoding"
+
+
+def test_get_accept_missing(server, files):
+    response = server.get(files.gzip_url, headers={})
+    assert response.content == files.gzip_content
+    assert response.headers["Content-Encoding"] == "gzip"
+    assert response.headers["Vary"] == "Accept-Encoding"
+
+
 def test_get_accept_gzip(server, files):
     response = server.get(files.gzip_url)
     assert response.content == files.gzip_content

--- a/tests/test_whitenoise.py
+++ b/tests/test_whitenoise.py
@@ -85,21 +85,25 @@ def test_get_file(server, files):
 def test_get_not_accept_gzip(server, files):
     response = server.get(files.gzip_url, headers={"Accept-Encoding": ""})
     assert response.content == files.gzip_content
-    assert response.headers.get("Content-Encoding", "") == ""
+    assert "Content-Encoding" not in response.headers
     assert response.headers["Vary"] == "Accept-Encoding"
 
 
 def test_get_accept_star(server, files):
     response = server.get(files.gzip_url, headers={"Accept-Encoding": "*"})
     assert response.content == files.gzip_content
-    assert response.headers["Content-Encoding"] == "gzip"
+    assert "Content-Encoding" not in response.headers
     assert response.headers["Vary"] == "Accept-Encoding"
 
 
 def test_get_accept_missing(server, files):
-    response = server.get(files.gzip_url, headers={"Accept-Encoding": None})
+    response = server.get(
+        files.gzip_url,
+        # Using None is required to override requests’ default Accept-Encoding
+        headers={"Accept-Encoding": None},
+    )
     assert response.content == files.gzip_content
-    assert response.headers.get("Content-Encoding", "") == ""
+    assert "Content-Encoding" not in response.headers
     assert response.headers["Vary"] == "Accept-Encoding"
 
 

--- a/tests/test_whitenoise.py
+++ b/tests/test_whitenoise.py
@@ -97,9 +97,9 @@ def test_get_accept_star(server, files):
 
 
 def test_get_accept_missing(server, files):
-    response = server.get(files.gzip_url, headers={})
+    response = server.get(files.gzip_url, headers={"Accept-Encoding": None})
     assert response.content == files.gzip_content
-    assert response.headers["Content-Encoding"] == "gzip"
+    assert response.headers.get("Content-Encoding", "") == ""
     assert response.headers["Vary"] == "Accept-Encoding"
 
 

--- a/whitenoise/responders.py
+++ b/whitenoise/responders.py
@@ -222,10 +222,10 @@ class StaticFile:
         return False
 
     def get_path_and_headers(self, request_headers):
-        accept_encoding = request_headers.get("HTTP_ACCEPT_ENCODING", "")
+        accept_encoding = request_headers.get("HTTP_ACCEPT_ENCODING", "*")
         # These are sorted by size so first match is the best
         for encoding_re, path, headers in self.alternatives:
-            if encoding_re.search(accept_encoding):
+            if accept_encoding == "*" or encoding_re.search(accept_encoding):
                 return path, headers
 
 

--- a/whitenoise/responders.py
+++ b/whitenoise/responders.py
@@ -222,7 +222,7 @@ class StaticFile:
         return False
 
     def get_path_and_headers(self, request_headers):
-        accept_encoding = request_headers.get("HTTP_ACCEPT_ENCODING", "*")
+        accept_encoding = request_headers.get("HTTP_ACCEPT_ENCODING", "")
         # These are sorted by size so first match is the best
         for encoding_re, path, headers in self.alternatives:
             if accept_encoding == "*" or encoding_re.search(accept_encoding):

--- a/whitenoise/responders.py
+++ b/whitenoise/responders.py
@@ -223,9 +223,11 @@ class StaticFile:
 
     def get_path_and_headers(self, request_headers):
         accept_encoding = request_headers.get("HTTP_ACCEPT_ENCODING", "")
+        if accept_encoding == "*":
+            accept_encoding = ""
         # These are sorted by size so first match is the best
         for encoding_re, path, headers in self.alternatives:
-            if accept_encoding == "*" or encoding_re.search(accept_encoding):
+            if encoding_re.search(accept_encoding):
                 return path, headers
 
 


### PR DESCRIPTION
* Adds support for "*" Accept-Encoding value
* Makes Accept-Encoding default to this value when missing as per spec
* Adds tests for both values

Fixes #303