### PR TITLE
Fix ResourceWarning for SlicedFile

### DIFF
--- a/whitenoise/responders.py
+++ b/whitenoise/responders.py
@@ -53,6 +53,9 @@ class SlicedFile(BufferedIOBase):
         self.remaining -= len(data)
         return data
 
+    def close(self):
+        self.fileobj.close()
+
 
 class StaticFile:
     def __init__(self, path, headers, encodings=None, stat_cache=None):


### PR DESCRIPTION
Due to lack of `close()` it was leaking warnings like:

```
tests/test_whitenoise.py::test_request_trailing_bytes[True]
  /.../wsgiref/handlers.py:337: ResourceWarning: unclosed file <_io.BufferedReader name='/var/folders/kq/02p9h16n7zv_z7bhzmg6y_pm0000gn/T/tmpd2dcglpa/subdir/javascript.js'>
    self.result = self.headers = self.status = self.environ = None
```

Adding a `close()` mirror allows the underlying file object to be closed at the right time.