### PR TITLE
Use contextlib.closing for AppServer fixtures

### DIFF
--- a/tests/test_django_whitenoise.py
+++ b/tests/test_django_whitenoise.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 import tempfile
+from contextlib import closing
 from urllib.parse import urljoin, urlparse
 
 import django
@@ -65,8 +66,8 @@ def application(_collect_static):
 @pytest.fixture(scope="module")
 def server(application):
     app_server = AppServer(application)
-    yield app_server
-    app_server.close()
+    with closing(app_server):
+        yield app_server
 
 
 def test_get_root_file(server, root_files, _collect_static):
@@ -152,8 +153,8 @@ def finder_application(finder_static_files):
 @pytest.fixture(scope="module")
 def finder_server(finder_application):
     app_server = AppServer(finder_application)
-    yield app_server
-    app_server.close()
+    with closing(app_server):
+        yield app_server
 
 
 def test_file_served_from_static_dir(finder_static_files, finder_server):

--- a/tests/test_whitenoise.py
+++ b/tests/test_whitenoise.py
@@ -7,6 +7,7 @@ import stat
 import sys
 import tempfile
 import warnings
+from contextlib import closing
 from urllib.parse import urljoin
 from wsgiref.headers import Headers
 from wsgiref.simple_server import demo_app
@@ -66,8 +67,8 @@ def _init_application(directory, **kwargs):
 @pytest.fixture(scope="module")
 def server(application):
     app_server = AppServer(application)
-    yield app_server
-    app_server.close()
+    with closing(app_server):
+        yield app_server
 
 
 def assert_is_default_response(response):


### PR DESCRIPTION
This makes sure the app server is closed when tests fail.