### PR TITLE
Fix changelog documentation page

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,40 +35,36 @@ Pending
 
 v5.3.0
 ------
- * Gracefully handle unparsable If-Modified-Since headers (thanks
-   `@danielegozzi <https://github.com/danielegozzi>`_).
- * Test against Django 3.2 (thanks `@jhnbkr <https://github.com/jhnbkr>`_).
- * Add mimetype for Markdown (``.md``) files (thanks `@bz2
-   <https://github.com/bz2>`_).
- * Various documentation improvements (thanks `@PeterJCLaw
-   <https://github.com/PeterJCLaw>`_ and `@AliRn76
-   <https://github.com/AliRn76>`_).
-
+* Gracefully handle unparsable If-Modified-Since headers (thanks
+  `@danielegozzi <https://github.com/danielegozzi>`_).
+* Test against Django 3.2 (thanks `@jhnbkr <https://github.com/jhnbkr>`_).
+* Add mimetype for Markdown (``.md``) files (thanks `@bz2
+  <https://github.com/bz2>`_).
+* Various documentation improvements (thanks `@PeterJCLaw
+  <https://github.com/PeterJCLaw>`_ and `@AliRn76
+  <https://github.com/AliRn76>`_).
 
 v5.2.0
 ------
 
- * Add support for `relative STATIC_URLs <https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-STATIC_URL>`_
-   in settings, as allowed in Django 3.1.
- * Add mimetype for ``.mjs`` (JavaScript module) files and use recommended
-   ``text/javascript`` mimetype for ``.js`` files (thanks `@hanswilw <https://github.com/hanswilw>`_).
- * Various documentation improvements (thanks `@lukeburden <https://github.com/lukeburden>`_).
-
+* Add support for `relative STATIC_URLs <https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-STATIC_URL>`_
+  in settings, as allowed in Django 3.1.
+* Add mimetype for ``.mjs`` (JavaScript module) files and use recommended
+  ``text/javascript`` mimetype for ``.js`` files (thanks `@hanswilw <https://github.com/hanswilw>`_).
+* Various documentation improvements (thanks `@lukeburden <https://github.com/lukeburden>`_).
 
 v5.1.0
 ------
 
- * Add a :any:`manifest_strict <WHITENOISE_MANIFEST_STRICT>` setting to prevent
-   Django throwing errors when missing files are referenced (thanks
-   `@MegacoderKim <https://github.com/MegacoderKim>`_).
-
+* Add a :any:`manifest_strict <WHITENOISE_MANIFEST_STRICT>` setting to prevent
+  Django throwing errors when missing files are referenced (thanks
+  `@MegacoderKim <https://github.com/MegacoderKim>`_).
 
 v5.0.1
 ------
 
- * Fix packaging to indicate only Python 3.5+ compatibiity (thanks `@mdalp
-   <https://github.com/mdalp>`_).
-
+* Fix packaging to indicate only Python 3.5+ compatibiity (thanks `@mdalp
+  <https://github.com/mdalp>`_).
 
 v5.0
 ----
@@ -81,67 +77,61 @@ v5.0
 
 Other changes include:
 
- * Fix incompatibility with Django 3.0 which caused problems with Safari
-   (details `here <https://github.com/evansd/whitenoise/issues/240>`_). Thanks
-   `@paltman <https://github.com/paltman>`_ and `@giilby
-   <https://github.com/giilby>`_ for diagnosing.
- * Lots of improvements to the test suite (including switching to py.test).
-   Thanks `@NDevox <https://github.com/ndevox>`_ and `@Djailla
-   <https://github.com/djailla>`_.
-
+* Fix incompatibility with Django 3.0 which caused problems with Safari
+  (details `here <https://github.com/evansd/whitenoise/issues/240>`_). Thanks
+  `@paltman <https://github.com/paltman>`_ and `@giilby
+  <https://github.com/giilby>`_ for diagnosing.
+* Lots of improvements to the test suite (including switching to py.test).
+  Thanks `@NDevox <https://github.com/ndevox>`_ and `@Djailla
+  <https://github.com/djailla>`_.
 
 v4.1.4
 ------
 
- * Make tests more deterministic and easier to run outside of ``tox``.
- * Fix Fedora packaging `issue <https://github.com/evansd/whitenoise/issues/225>`_.
- * Use `Black <https://github.com/psf/black>`_ to format all code.
-
+* Make tests more deterministic and easier to run outside of ``tox``.
+* Fix Fedora packaging `issue <https://github.com/evansd/whitenoise/issues/225>`_.
+* Use `Black <https://github.com/psf/black>`_ to format all code.
 
 v4.1.3
 ------
 
- * Fix handling of zero-valued mtimes which can occur when running on some
-   filesystems (thanks `@twosigmajab <https://github.com/twosigmajab>`_ for
-   reporting).
- * Fix potential path traversal attack while running in autorefresh mode on
-   Windows (thanks `@phith0n <https://github.com/phith0n>`_ for reporting).
-   This is a good time to reiterate that autofresh mode is never intended for
-   production use.
-
+* Fix handling of zero-valued mtimes which can occur when running on some
+  filesystems (thanks `@twosigmajab <https://github.com/twosigmajab>`_ for
+  reporting).
+* Fix potential path traversal attack while running in autorefresh mode on
+  Windows (thanks `@phith0n <https://github.com/phith0n>`_ for reporting).
+  This is a good time to reiterate that autofresh mode is never intended for
+  production use.
 
 v4.1.2
 ------
 
- * Add correct MIME type for WebAssembly, which is required for files to be
-   executed (thanks `@mdboom <https://github.com/mdboom>`_ ).
- * Stop accessing the FILE_CHARSET Django setting which was almost entirely
-   unused and is now deprecated (thanks `@timgraham
-   <https://github.com/timgraham>`_).
-
+* Add correct MIME type for WebAssembly, which is required for files to be
+  executed (thanks `@mdboom <https://github.com/mdboom>`_ ).
+* Stop accessing the FILE_CHARSET Django setting which was almost entirely
+  unused and is now deprecated (thanks `@timgraham
+  <https://github.com/timgraham>`_).
 
 v4.1.1
 ------
 
- * Fix `bug <https://github.com/evansd/whitenoise/issues/202>`_ in ETag
-   handling (thanks `@edmorley <https://github.com/edmorley>`_).
- * Documentation fixes (thanks `@jamesbeith <https://github.com/jamesbeith>`_
-   and `@mathieusteele <https://github.com/mathieusteele>`_).
-
+* Fix `bug <https://github.com/evansd/whitenoise/issues/202>`_ in ETag
+  handling (thanks `@edmorley <https://github.com/edmorley>`_).
+* Documentation fixes (thanks `@jamesbeith <https://github.com/jamesbeith>`_
+  and `@mathieusteele <https://github.com/mathieusteele>`_).
 
 v4.1
 ----
 
- * Silenced spurious warning about missing directories when in development (i.e
-   "autorefresh") mode.
- * Support supplying paths as `Pathlib
-   <https://docs.python.org/3.4/library/pathlib.html>`_ instances, rather than
-   just strings (thanks `@browniebroke <https://github.com/browniebroke>`_).
- * Add a new :ref:`CompressedStaticFilesStorage <compression-and-caching>`
-   backend to support applying compression without applying Django's hash-versioning
-   process.
- * Documentation improvements.
-
+* Silenced spurious warning about missing directories when in development (i.e
+  "autorefresh") mode.
+* Support supplying paths as `Pathlib
+  <https://docs.python.org/3.4/library/pathlib.html>`_ instances, rather than
+  just strings (thanks `@browniebroke <https://github.com/browniebroke>`_).
+* Add a new :ref:`CompressedStaticFilesStorage <compression-and-caching>`
+  backend to support applying compression without applying Django's hash-versioning
+  process.
+* Documentation improvements.
 
 v4.0
 ----
@@ -150,47 +140,40 @@ v4.0
           The latest version of WhiteNoise removes some options which were
           deprecated in the previous major release:
 
-    * The WSGI integration option for Django
-      (which involved editing ``wsgi.py``) has been removed. Instead, you
-      should add WhiteNoise to your
-      middleware list in ``settings.py`` and remove any reference to WhiteNoise from
-      ``wsgi.py``.
-      See the :ref:`documentation <django-middleware>` for more details. |br|
-      (The :doc:`pure WSGI <base>` integration is still available for non-Django apps.)
+* The WSGI integration option for Django
+  (which involved editing ``wsgi.py``) has been removed. Instead, you
+  should add WhiteNoise to your
+  middleware list in ``settings.py`` and remove any reference to WhiteNoise from
+  ``wsgi.py``.
+  See the :ref:`documentation <django-middleware>` for more details. |br|
+  (The :doc:`pure WSGI <base>` integration is still available for non-Django apps.)
 
-    * The ``whitenoise.django.GzipManifestStaticFilesStorage`` alias has now
-      been removed. Instead you should use the correct import path:
-      ``whitenoise.storage.CompressedManifestStaticFilesStorage``.
+* The ``whitenoise.django.GzipManifestStaticFilesStorage`` alias has now
+  been removed. Instead you should use the correct import path:
+  ``whitenoise.storage.CompressedManifestStaticFilesStorage``.
 
-    If you are not using either of these integration options you should have
-    no issues upgrading to the latest version.
+If you are not using either of these integration options you should have
+no issues upgrading to the latest version.
 
-Removed Python 3.3 Support
-++++++++++++++++++++++++++
+.. rubric:: Removed Python 3.3 Support
 
 Removed support for Python 3.3 since it's end of life was in September 2017.
 
-
-Index file support
-++++++++++++++++++
+.. rubric:: Index file support
 
 WhiteNoise now supports serving :ref:`index files <index-files-django>` for
 directories (e.g. serving ``/example/index.html`` at ``/example/``). It also
 creates redirects so that visiting the index file directly, or visiting the URL
 without a trailing slash will redirect to the correct URL.
 
-
-Range header support ("byte serving")
-+++++++++++++++++++++++++++++++++++++
+.. rubric:: Range header support ("byte serving")
 
 WhiteNoise now respects the HTTP Range header which allows a client to request
 only part of a file. The main use for this is in serving video files to iOS
 devices as Safari refuses to play videos unless the server supports the
 Range header.
 
-
-ETag support
-++++++++++++
+.. rubric:: ETag support
 
 WhiteNoise now adds ETag headers to files using the same algorithm used by
 nginx. This gives slightly better caching behaviour than relying purely on Last
@@ -201,9 +184,7 @@ if you can use it).
 If you need to generate your own ETags headers for any reason you can define a
 custom :any:`add_headers_function <WHITENOISE_ADD_HEADERS_FUNCTION>`.
 
-
-Remove requirement to run collectstatic
-+++++++++++++++++++++++++++++++++++++++
+.. rubric:: Remove requirement to run collectstatic
 
 By setting :any:`WHITENOISE_USE_FINDERS` to ``True`` files will be served
 directly from their original locations (usually in ``STATICFILES_DIRS`` or app
@@ -216,9 +197,7 @@ backends this simplifies the deployment process by removing the need to run
 collectstatic as part of the build step -- in fact, it's now possible not to
 have any build step at all.
 
-
-Customisable immutable files test
-+++++++++++++++++++++++++++++++++
+.. rubric:: Customisable immutable files test
 
 WhiteNoise ships with code which detects when you are using Django's
 ManifestStaticFilesStorage backend and sends optimal caching headers for files
@@ -227,9 +206,7 @@ generating cacheable files then you might need to supply your own function for
 detecting such files. Previously this required subclassing WhiteNoise, but now
 you can use the :any:`WHITENOISE_IMMUTABLE_FILE_TEST` setting.
 
-
-Fix runserver_nostatic to work with Channels
-++++++++++++++++++++++++++++++++++++++++++++
+.. rubric:: Fix runserver_nostatic to work with Channels
 
 The old implementation of :ref:`runserver_nostatic <runserver-nostatic>` (which
 disables Django's default static file handling in development) did not work
@@ -239,19 +216,14 @@ Channels and with any other app which provides its own runserver.
 
 .. _Channels: https://channels.readthedocs.io/
 
-
-Reduced storage requirements for static files
-+++++++++++++++++++++++++++++++++++++++++++++
+.. rubric:: Reduced storage requirements for static files
 
 The new :any:`WHITENOISE_KEEP_ONLY_HASHED_FILES` setting reduces the number of
 files in STATIC_ROOT by half by storing files only under their hashed names
 (e.g.  ``app.db8f2edc0c8a.js``), rather than also keeping a copy with the
 original name (e.g. ``app.js``).
 
-
-
-Improved start up performance
-+++++++++++++++++++++++++++++
+.. rubric:: Improved start up performance
 
 When in production mode (i.e. when :any:`autorefresh <WHITENOISE_AUTOREFRESH>`
 is disabled), WhiteNoise scans all static files when the application starts in
@@ -262,17 +234,13 @@ some time. In WhiteNoise 4.0 the file scanning code has been rewritten to do
 the minimum possible amount of filesystem access which should make the start up
 process considerably faster.
 
-
-Windows Testing
-+++++++++++++++
+.. rubric:: Windows Testing
 
 WhiteNoise has always aimed to support Windows as well as \*NIX platforms but
 we are now able to run the test suite against Windows as part of the CI process
 which should ensure that we can maintain Windows compatibility in future.
 
-
-Modification times for compressed files
-+++++++++++++++++++++++++++++++++++++++
+.. rubric:: Modification times for compressed files
 
 The compressed storage backend (which generates Gzip and Brotli compressed
 files) now ensures that compressed files have the same modification time as the
@@ -280,8 +248,7 @@ originals.  This only makes a difference if you are using the compression
 backend with something other than WhiteNoise to actually serve the files, which
 very few users do.
 
-Replaced brotlipy with official Brotli Python Package
-+++++++++++++++++++++++++++++++++++++++++++++++++++++
+.. rubric:: Replaced brotlipy with official Brotli Python Package
 
 Since the official `Brotli project <https://github.com/google/brotli>`_ offers
 a `Brotli Python package <https://pypi.org/project/Brotli/>`_ brotlipy has been
@@ -294,60 +261,57 @@ installing WhiteNoise and Brotli together like this:
 
     pip install whitenoise[brotli]
 
-
----------------------------
-
 v3.3.1
 ------
 
- * Fix issue with the immutable file test when running behind a CDN which rewrites
-   paths (thanks @lskillen).
+* Fix issue with the immutable file test when running behind a CDN which rewrites
+  paths (thanks @lskillen).
 
 v3.3.0
 ------
 
- * Support the new `immutable <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Revalidation_and_reloading>`_
-   Cache-Control header. This gives better caching behaviour for immutable resources than
-   simply setting a large max age.
+* Support the new `immutable <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Revalidation_and_reloading>`_
+  Cache-Control header. This gives better caching behaviour for immutable resources than
+  simply setting a large max age.
 
 v3.2.3
 ------
 
- * Gracefully handle invalid byte sequences in URLs.
- * Gracefully handle filenames which are too long for the filesystem.
- * Send correct Content-Type for Adobe's ``crossdomain.xml`` files.
+* Gracefully handle invalid byte sequences in URLs.
+* Gracefully handle filenames which are too long for the filesystem.
+* Send correct Content-Type for Adobe's ``crossdomain.xml`` files.
 
 v3.2.2
 ------
 
- * Convert any config values supplied as byte strings to text to avoid
-   runtime encoding errors when encountering non-ASCII filenames.
+* Convert any config values supplied as byte strings to text to avoid
+  runtime encoding errors when encountering non-ASCII filenames.
 
 v3.2.1
 ------
 
- * Handle non-ASCII URLs correctly when using the ``wsgi.py`` integration.
- * Fix exception triggered when a static files "finder" returned a directory
-   rather than a file.
+* Handle non-ASCII URLs correctly when using the ``wsgi.py`` integration.
+* Fix exception triggered when a static files "finder" returned a directory
+  rather than a file.
 
 v3.2
 ----
 
- * Add support for the new-style middleware classes introduced in Django 1.10.
-   The same WhiteNoiseMiddleware class can now be used in either the old
-   ``MIDDLEWARE_CLASSES`` list or the new ``MIDDLEWARE`` list.
- * Fixed a bug where incorrect Content-Type headers were being sent on 304 Not
-   Modified responses (thanks `@oppianmatt <https://github.com/oppianmatt>`_).
- * Return Vary and Cache-Control headers on 304 responses, as specified by the
-   `RFC <https://tools.ietf.org/html/rfc7232#section-4.1>`_.
+* Add support for the new-style middleware classes introduced in Django 1.10.
+  The same WhiteNoiseMiddleware class can now be used in either the old
+  ``MIDDLEWARE_CLASSES`` list or the new ``MIDDLEWARE`` list.
+* Fixed a bug where incorrect Content-Type headers were being sent on 304 Not
+  Modified responses (thanks `@oppianmatt <https://github.com/oppianmatt>`_).
+* Return Vary and Cache-Control headers on 304 responses, as specified by the
+  `RFC <https://tools.ietf.org/html/rfc7232#section-4.1>`_.
 
 v3.1
 ----
 
- * Add new :any:`WHITENOISE_STATIC_PREFIX` setting to give flexibility in
-   supporting non-standard deployment configurations e.g. serving the
-   application somewhere other than the domain root.
- * Fix bytes/unicode bug when running with Django 1.10 on Python 2.7
+* Add new :any:`WHITENOISE_STATIC_PREFIX` setting to give flexibility in
+  supporting non-standard deployment configurations e.g. serving the
+  application somewhere other than the domain root.
+* Fix bytes/unicode bug when running with Django 1.10 on Python 2.7
 
 v3.0
 ----
@@ -356,28 +320,26 @@ v3.0
    Most users will be able to upgrade without any problems, but some
    less-used APIs have been modified:
 
-    * The setting ``WHITENOISE_GZIP_EXCLUDE_EXTENSIONS`` has been renamed to
-      ``WHITENOISE_SKIP_COMPRESS_EXTENSIONS``.
-    * The CLI :ref:`compression utility <cli-utility>` has moved from ``python -m whitenoise.gzip``
-      to ``python -m whitenoise.compress``.
-    * The now redundant ``gzipstatic`` management command has been removed.
-    * WhiteNoise no longer uses the system mimetypes files, so if you are serving
-      particularly obscure filetypes you may need to add their mimetypes explicitly
-      using the new :any:`mimetypes <WHITENOISE_MIMETYPES>` setting.
-    * Older versions of Django (1.4-1.7) and Python (2.6) are no longer supported.
-      If you need support for these platforms you can continue to use `WhiteNoise
-      2.x`_.
-    * The ``whitenoise.django.GzipManifestStaticFilesStorage`` storage backend
-      has been moved to
-      ``whitenoise.storage.CompressedManifestStaticFilesStorage``.  The old
-      import path **will continue to work** for now, but users are encouraged
-      to update their code to use the new path.
+* The setting ``WHITENOISE_GZIP_EXCLUDE_EXTENSIONS`` has been renamed to
+  ``WHITENOISE_SKIP_COMPRESS_EXTENSIONS``.
+* The CLI :ref:`compression utility <cli-utility>` has moved from ``python -m whitenoise.gzip``
+  to ``python -m whitenoise.compress``.
+* The now redundant ``gzipstatic`` management command has been removed.
+* WhiteNoise no longer uses the system mimetypes files, so if you are serving
+  particularly obscure filetypes you may need to add their mimetypes explicitly
+  using the new :any:`mimetypes <WHITENOISE_MIMETYPES>` setting.
+* Older versions of Django (1.4-1.7) and Python (2.6) are no longer supported.
+  If you need support for these platforms you can continue to use `WhiteNoise
+  2.x`_.
+* The ``whitenoise.django.GzipManifestStaticFilesStorage`` storage backend
+  has been moved to
+  ``whitenoise.storage.CompressedManifestStaticFilesStorage``.  The old
+  import path **will continue to work** for now, but users are encouraged
+  to update their code to use the new path.
 
 .. _WhiteNoise 2.x: https://whitenoise.evans.io/en/legacy-2.x/
 
-
-Simpler, cleaner Django middleware integration
-++++++++++++++++++++++++++++++++++++++++++++++
+.. rubric:: Simpler, cleaner Django middleware integration
 
 WhiteNoise can now integrate with Django by adding a single line to
 ``MIDDLEWARE_CLASSES``  without any need to edit ``wsgi.py``. This also means
@@ -387,9 +349,7 @@ system. See the :ref:`updated documentation <django-middleware>` for details.
 
 .. _Channels: https://channels.readthedocs.io/
 
-
-Brotli compression support
-++++++++++++++++++++++++++
+.. rubric:: Brotli compression support
 
 `Brotli`_ is the modern, more efficient alternative to gzip for HTTP
 compression. To benefit from smaller files and faster page loads, just install
@@ -400,17 +360,13 @@ for details.
 .. _brotli: https://en.wikipedia.org/wiki/Brotli
 .. _brotlipy: https://brotlipy.readthedocs.io/
 
-
-Simpler customisation
-+++++++++++++++++++++
+.. rubric:: Simpler customisation
 
 It's now possible to add custom headers to WhiteNoise without needing to create
 a subclass, using the new :any:`add_headers_function
 <WHITENOISE_ADD_HEADERS_FUNCTION>` setting.
 
-
-Use WhiteNoise in development with Django
-+++++++++++++++++++++++++++++++++++++++++
+.. rubric:: Use WhiteNoise in development with Django
 
 There's now an option to force Django to use WhiteNoise in development, rather
 than its own static file handling. This results in more consistent behaviour
@@ -418,10 +374,7 @@ between development and production environments and fewer opportunities for
 bugs and surprises. See the :ref:`documentation <runserver-nostatic>` for
 details.
 
-
-
-Improved mimetype handling
-++++++++++++++++++++++++++
+.. rubric:: Improved mimetype handling
 
 WhiteNoise now ships with its own mimetype definitions (based on those shipped
 with nginx) instead of relying on the system ones, which can vary between
@@ -429,65 +382,51 @@ environments. There is a new :any:`mimetypes <WHITENOISE_MIMETYPES>`
 configuration option which makes it easy to add additional type definitions if
 needed.
 
-
-Thanks
-++++++
+.. rubric:: Thanks
 
 A big thank-you to `Ed Morley <https://github.com/edmorley>`_ and `Tim Graham
 <https://github.com/timgraham>`_ for their contributions to this release.
-
----------------------------
-
 
 v2.0.6
 ------
 * Rebuild with latest version of `wheel` to get `extras_require` support.
 
-
 v2.0.5
 ------
 * Add missing argparse dependency for Python 2.6 (thanks @movermeyer)).
-
 
 v2.0.4
 ------
 * Report path on MissingFileError (thanks @ezheidtmann).
 
-
 v2.0.3
 ------
 * Add `__version__` attribute.
 
-
 v2.0.2
 ------
 * More helpful error message when STATIC_URL is set to the root of a domain (thanks @dominicrodger).
-
 
 v2.0.1
 ------
 * Add support for Python 2.6.
 * Add a more helpful error message when attempting to import DjangoWhiteNoise before `DJANGO_SETTINGS_MODULE` is defined.
 
-
 v2.0
-------
+----
 * Add an `autorefresh` mode which picks up changes to static files made after application startup (for use in development).
 * Add a `use_finders` mode for DjangoWhiteNoise which finds files in their original directories without needing them collected in `STATIC_ROOT` (for use in development). Note, this is only useful if you don't want to use Django's default runserver behaviour.
 * Remove the `follow_symlinks` argument from `add_files` and now always follow symlinks.
 * Support extra mimetypes which Python doesn't know about by default (including .woff2 format)
 * Some internal refactoring. Note, if you subclass WhiteNoise to add custom behaviour you may need to make some small changes to your code.
 
-
 v1.0.6
 ------
 * Fix unhelpful exception inside `make_helpful_exception` on Python 3 (thanks @abbottc).
 
-
 v1.0.5
 ------
 * Fix error when attempting to gzip empty files (thanks @ryanrhee).
-
 
 v1.0.4
 ------
@@ -495,22 +434,18 @@ v1.0.4
 * Base decision to gzip on compression ratio achieved, so we don't incur gzip overhead just to save a few bytes.
 * More helpful error message from ``collectstatic`` if CSS files reference missing assets.
 
-
 v1.0.3
 ------
 * Fix bug in Last Modified date handling (thanks to Atsushi Odagiri for spotting).
-
 
 v1.0.2
 ------
 * Set the default max_age parameter in base class to be what the docs claimed it was.
 
-
 v1.0.1
 ------
 * Fix path-to-URL conversion for Windows.
 * Remove cruft from packaging manifest.
-
 
 v1.0
 ----


### PR DESCRIPTION
After the sphinx theme change to 'furo' for the 'whitenoise' documentation I noticed some issue in the changelog page.
http://whitenoise.evans.io/en/latest/changelog.html