### PR TITLE
Remove whitenoise.django compatibility module

### DIFF
--- a/whitenoise/django.py
+++ b/whitenoise/django.py
@@ -1,9 +1,0 @@
-from __future__ import annotations
-
-raise ImportError(
-    "\n\n"
-    "Your WhiteNoise configuration is incompatible with WhiteNoise v4.0\n"
-    "This can be fixed by following the upgrade instructions at:\n"
-    "https://whitenoise.evans.io/en/stable/changelog.html#v4-0\n"
-    "\n"
-)


### PR DESCRIPTION
This has errored since Whitenoise 4, so it’s reasonable to assume everyone affected has upgraded.