### PR TITLE
Refactor MediaTypes

### DIFF
--- a/tests/test_media_types.py
+++ b/tests/test_media_types.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from whitenoise.media_types import MediaTypes
+
+
+def test_matched_filename():
+    result = MediaTypes().get_type("static/apple-app-site-association")
+    assert result == "application/pkc7-mime"
+
+
+def test_matched_filename_cased():
+    result = MediaTypes().get_type("static/Apple-App-Site-Association")
+    assert result == "application/pkc7-mime"
+
+
+def test_matched_extension():
+    result = MediaTypes().get_type("static/app.js")
+    assert result == "text/javascript"
+
+
+def test_unmatched_extension():
+    result = MediaTypes().get_type("static/app.example-unmatched")
+    assert result == "application/octet-stream"
+
+
+def test_extra_types():
+    types = MediaTypes(extra_types={".js": "application/javascript"})
+    result = types.get_type("static/app.js")
+    assert result == "application/javascript"

--- a/whitenoise/media_types.py
+++ b/whitenoise/media_types.py
@@ -4,10 +4,11 @@ import os
 
 
 class MediaTypes:
-    def __init__(self, default="application/octet-stream", extra_types=None):
+    __slots__ = ("types_map",)
+
+    def __init__(self, *, extra_types=None):
         self.types_map = default_types()
-        self.default = default
-        if extra_types:
+        if extra_types is not None:
             self.types_map.update(extra_types)
 
     def get_type(self, path):
@@ -16,7 +17,7 @@ class MediaTypes:
         if media_type is not None:
             return media_type
         extension = os.path.splitext(name)[1]
-        return self.types_map.get(extension, self.default)
+        return self.types_map.get(extension, "application/octet-stream")
 
 
 def default_types():


### PR DESCRIPTION
* Move default into `get_types`, since WhiteNoise has never had a public API to change it, and it’s a bit faster as a function const.
* Add full test coverage.
* Make `extra_types` a keyword-only argument, and add `__slots__` to save a few bytes of memory.