### PR TITLE
Improve compress module test coverage

### DIFF
--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -32,7 +32,7 @@ def files_dir():
             f.write(contents)
         timestamp = 1498579535
         os.utime(path, (timestamp, timestamp))
-    compress_main(tmp, quiet=True)
+    compress_main([tmp, "--quiet"])
     yield tmp
     shutil.rmtree(tmp)
 


### PR DESCRIPTION
* Hoist creation of argument parser into `main()`, and in general follow my [script template](https://adamj.eu/tech/2021/10/09/a-python-script-template-with-and-without-type-hints-and-async/)
* Mark unreachable blocks as `# pragma: no cover`