### PR TITLE
Tidy MANIFEST.in and remove check-manifest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,8 +41,3 @@ repos:
     - flake8-comprehensions
     - flake8-tidy-imports
     - flake8-typing-imports
-- repo: https://github.com/mgedmin/check-manifest
-  rev: "0.48"
-  hooks:
-  - id: check-manifest
-    args: [--no-build-isolation]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,14 +1,7 @@
-global-exclude *.py[cod]
-prune __pycache__
 prune docs
-prune requirements
 prune scripts
-prune tests
-exclude .editorconfig
-exclude .pre-commit-config.yaml
 exclude .readthedocs.yaml
 exclude CHANGELOG.rst
-exclude tox.ini
 include LICENSE
 include pyproject.toml
 include README.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Topic :: Internet :: WWW/HTTP :: WSGI :: Middleware
-license_file = LICENSE
 
 [options]
 package_dir=


### PR DESCRIPTION
Delete some unnecessary entries from MANIFEST.in which trigger warnings from setuptools, and remove check-manifest which requires these unnecessary entries. Should be fine without check-manifest as tox uses isolated builds now.
