### PR TITLE
Fix typo

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -116,7 +116,7 @@ Compatibility
 WhiteNoise works with any WSGI-compatible application and is tested on Python
 **3.7** – **3.10**, on both Linux and Windows.
 
-Django WhiteNoiseMiddlware is tested with Django versions **2.2** --- **4.0**
+Django WhiteNoiseMiddleware is tested with Django versions **2.2** --- **4.0**
 
 
 Endorsements


### PR DESCRIPTION
Missing 'e' in Middle