### PR TITLE
Add video file extensions to the default skip list

### DIFF
--- a/src/whitenoise/compress.py
+++ b/src/whitenoise/compress.py
@@ -42,7 +42,6 @@ class Compressor:
         "3gp",
         "3gpp",
         "asf",
-        "asx",
         "avi",
         "m4v",
         "mov",

--- a/src/whitenoise/compress.py
+++ b/src/whitenoise/compress.py
@@ -38,6 +38,19 @@ class Compressor:
         # Fonts
         "woff",
         "woff2",
+        # Video
+        "3gp",
+        "3gpp",
+        "asf",
+        "asx",
+        "avi",
+        "m4v",
+        "mov",
+        "mp4",
+        "mpeg",
+        "mpg",
+        "webm",
+        "wmv",
     )
 
     def __init__(


### PR DESCRIPTION
Whitenoise attempts to compress video files, which is a huge waste of time and disk space (given video files tend to be large and slow to compress, especially with brotli), as of course neither gzip nor brotli will manage to do any meaningful compression on an already-compressed video file. Also I think browsers will tend to do byte-range requests on video files, which of course cannot use the compressed versions. So I think the common video-file extensions should be added to the default `WHITENOISE_SKIP_COMPRESS_EXTENSIONS`.