### PR TITLE
Remove unnecessary warning filter from tests

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,14 +2,10 @@ from __future__ import annotations
 
 import os
 import threading
-import warnings
 from wsgiref.simple_server import WSGIRequestHandler, make_server
 from wsgiref.util import shift_path_info
 
 import requests
-
-warnings.filterwarnings(action="ignore", category=DeprecationWarning, module="requests")
-
 
 TEST_FILE_PATH = os.path.join(os.path.dirname(__file__), "test_files")
 


### PR DESCRIPTION
Added in 4e5e034651e7c0ebcafb9944fefcc4cc3d7a2d14 but since rendered unnecessary, whatever was deprecated has been removed or otherwise resolved.