### PR TITLE
Merge HelpfulExceptionMixin into CompressedManifestStaticFilesStorage

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -13,11 +13,7 @@ from django.core.management import call_command
 from django.test.utils import override_settings
 from django.utils.functional import empty
 
-from whitenoise.storage import (
-    CompressedManifestStaticFilesStorage,
-    HelpfulExceptionMixin,
-    MissingFileError,
-)
+from whitenoise.storage import CompressedManifestStaticFilesStorage, MissingFileError
 
 from .utils import Files
 
@@ -69,7 +65,7 @@ def test_make_helpful_exception(_compressed_manifest_storage):
         TriggerException().hashed_name("/missing/file.png")
     except ValueError as e:
         exception = e
-    helpful_exception = HelpfulExceptionMixin().make_helpful_exception(
+    helpful_exception = CompressedManifestStaticFilesStorage().make_helpful_exception(
         exception, "styles/app.css"
     )
     assert isinstance(helpful_exception, MissingFileError)


### PR DESCRIPTION
Split from #410. Type hints with mixin inheritance is annoying - easier to combine the mixin class that exists only for code organization.