### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.pytest.ini_options]
 addopts = """\
     --strict-config

--- a/src/whitenoise/base.py
+++ b/src/whitenoise/base.py
@@ -9,12 +9,13 @@ from wsgiref.headers import Headers
 from wsgiref.util import FileWrapper
 
 from .media_types import MediaTypes
-from .responders import IsDirectoryError, MissingFileError, Redirect, StaticFile
-from .string_utils import (
-    decode_if_byte_string,
-    decode_path_info,
-    ensure_leading_trailing_slash,
-)
+from .responders import IsDirectoryError
+from .responders import MissingFileError
+from .responders import Redirect
+from .responders import StaticFile
+from .string_utils import decode_if_byte_string
+from .string_utils import decode_path_info
+from .string_utils import ensure_leading_trailing_slash
 
 
 class WhiteNoise:

--- a/src/whitenoise/middleware.py
+++ b/src/whitenoise/middleware.py
@@ -11,7 +11,8 @@ from django.http import FileResponse
 from django.urls import get_script_prefix
 
 from .base import WhiteNoise
-from .string_utils import decode_if_byte_string, ensure_leading_trailing_slash
+from .string_utils import decode_if_byte_string
+from .string_utils import ensure_leading_trailing_slash
 
 __all__ = ["WhiteNoiseMiddleware"]
 

--- a/src/whitenoise/responders.py
+++ b/src/whitenoise/responders.py
@@ -4,7 +4,8 @@ import errno
 import os
 import re
 import stat
-from email.utils import formatdate, parsedate
+from email.utils import formatdate
+from email.utils import parsedate
 from http import HTTPStatus
 from io import BufferedIOBase
 from time import mktime

--- a/src/whitenoise/storage.py
+++ b/src/whitenoise/storage.py
@@ -6,10 +6,8 @@ import re
 import textwrap
 
 from django.conf import settings
-from django.contrib.staticfiles.storage import (
-    ManifestStaticFilesStorage,
-    StaticFilesStorage,
-)
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+from django.contrib.staticfiles.storage import StaticFilesStorage
 
 from .compress import Compressor
 

--- a/tests/django_settings.py
+++ b/tests/django_settings.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import os.path
 
-from .utils import TEST_FILE_PATH, AppServer
+from .utils import AppServer
+from .utils import TEST_FILE_PATH
 
 ALLOWED_HOSTS = ["*"]
 

--- a/tests/test_django_whitenoise.py
+++ b/tests/test_django_whitenoise.py
@@ -3,19 +3,22 @@ from __future__ import annotations
 import shutil
 import tempfile
 from contextlib import closing
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin
+from urllib.parse import urlparse
 
 import pytest
 from django.conf import settings
-from django.contrib.staticfiles import finders, storage
+from django.contrib.staticfiles import finders
+from django.contrib.staticfiles import storage
 from django.core.management import call_command
 from django.core.wsgi import get_wsgi_application
 from django.test.utils import override_settings
 from django.utils.functional import empty
 
-from whitenoise.middleware import WhiteNoiseFileResponse, WhiteNoiseMiddleware
-
-from .utils import AppServer, Files
+from .utils import AppServer
+from .utils import Files
+from whitenoise.middleware import WhiteNoiseFileResponse
+from whitenoise.middleware import WhiteNoiseMiddleware
 
 
 def reset_lazy_object(obj):

--- a/tests/test_runserver_nostatic.py
+++ b/tests/test_runserver_nostatic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from django.core.management import get_commands, load_command_class
+from django.core.management import get_commands
+from django.core.management import load_command_class
 
 
 def get_command_instance(name):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -8,14 +8,15 @@ from posixpath import basename
 
 import pytest
 from django.conf import settings
-from django.contrib.staticfiles.storage import HashedFilesMixin, staticfiles_storage
+from django.contrib.staticfiles.storage import HashedFilesMixin
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.management import call_command
 from django.test.utils import override_settings
 from django.utils.functional import empty
 
-from whitenoise.storage import CompressedManifestStaticFilesStorage, MissingFileError
-
 from .utils import Files
+from whitenoise.storage import CompressedManifestStaticFilesStorage
+from whitenoise.storage import MissingFileError
 
 
 @pytest.fixture()

--- a/tests/test_string_utils.py
+++ b/tests/test_string_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from whitenoise.string_utils import decode_if_byte_string, ensure_leading_trailing_slash
+from whitenoise.string_utils import decode_if_byte_string
+from whitenoise.string_utils import ensure_leading_trailing_slash
 
 
 class DecodeIfByteStringTests:

--- a/tests/test_whitenoise.py
+++ b/tests/test_whitenoise.py
@@ -14,10 +14,10 @@ from wsgiref.simple_server import demo_app
 
 import pytest
 
+from .utils import AppServer
+from .utils import Files
 from whitenoise import WhiteNoise
 from whitenoise.responders import StaticFile
-
-from .utils import AppServer, Files
 
 
 @pytest.fixture(scope="module")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import os
 import threading
-from wsgiref.simple_server import WSGIRequestHandler, make_server
+from wsgiref.simple_server import make_server
+from wsgiref.simple_server import WSGIRequestHandler
 from wsgiref.util import shift_path_info
 
 import requests


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
