### PR TITLE
Fix docs build warning about overriding file

### DIFF
--- a/docs/base.rst
+++ b/docs/base.rst
@@ -206,7 +206,7 @@ sub-classing WhiteNoise and setting the attributes directly.
     Note that WhiteNoise ships with its own default set of mimetypes and does
     not use the system-supplied ones (e.g. ``/etc/mime.types``). This ensures
     that it behaves consistently regardless of the environment in which it's
-    run.  View the defaults in the :file:`media_types.py
+    run.  View the defaults in the :ghfile:`media_types.py
     <whitenoise/media_types.py>` file.
 
     In addition to file extensions, mimetypes can be specified by supplying the entire

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,4 +126,4 @@ texinfo_documents = [
 
 git_tag = f"{version}" if version != "development" else "main"
 github_base_url = f"https://github.com/evansd/whitenoise/blob/{git_tag}/src/"
-extlinks = {"file": (github_base_url + "%s", "")}
+extlinks = {"ghfile": (github_base_url + "%s", "")}

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -340,7 +340,7 @@ arguments upper-cased with a 'WHITENOISE\_' prefix.
     Note that WhiteNoise ships with its own default set of mimetypes and does
     not use the system-supplied ones (e.g. ``/etc/mime.types``). This ensures
     that it behaves consistently regardless of the environment in which it's
-    run.  View the defaults in the :file:`media_types.py
+    run.  View the defaults in the :ghfile:`media_types.py
     <whitenoise/media_types.py>` file.
 
     In addition to file extensions, mimetypes can be specified by supplying the entire
@@ -424,7 +424,7 @@ arguments upper-cased with a 'WHITENOISE\_' prefix.
 
 .. attribute:: WHITENOISE_IMMUTABLE_FILE_TEST
 
-    :default: See :file:`immutable_file_test <whitenoise/middleware.py#L134>` in source
+    :default: See :ghfile:`immutable_file_test <whitenoise/middleware.py#L134>` in source
 
     Reference to function, or string.
 


### PR DESCRIPTION
This role already exists with a different meaning: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-file

Sphinx warns:

```
WARNING: role 'file' is already registered, it will be overridden
```

6ed35afc40f4225af7c9dca72d4796d996ace699 made Sphinx fail on warnings