### PR TITLE
Fix issue with static files on Windows

### DIFF
--- a/src/whitenoise/middleware.py
+++ b/src/whitenoise/middleware.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import os
-from posixpath import basename
+from posixpath import basename, normpath
 from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 from django.conf import settings
 from django.contrib.staticfiles import finders
@@ -155,7 +156,10 @@ class WhiteNoiseMiddleware(WhiteNoise):
 
     def candidate_paths_for_url(self, url):
         if self.use_finders and url.startswith(self.static_prefix):
-            path = finders.find(url[len(self.static_prefix) :])
+            relative_url = url[len(self.static_prefix) :]
+            path = url2pathname(relative_url)
+            normalized_path = normpath(path).lstrip('/')
+            path = finders.find(normalized_path)
             if path:
                 yield path
         paths = super().candidate_paths_for_url(url)


### PR DESCRIPTION
See [https://github.com/evansd/whitenoise/issues/472](https://github.com/evansd/whitenoise/issues/472)
also [https://code.djangoproject.com/ticket/34341](https://code.djangoproject.com/ticket/34341)

The probable takeaway from the discussion on Django side is that `finders.find()` is really supposed to be called with an OS-standardized path.

I've mimicked what Django does to an url before calling `finders.find()`:
- step 1 (strip url base / prefix) was already done by whitenoise
- step 2 (`url2pathname`) is obvious enough
- step 3 (using `posixpath.normpath`, plus `.lstrip('/')`) seems debatable considering that we're already after `url2pathname`, but for the sake of mimicking Django I've included it