### PR TITLE
Fix warning.warn call

### DIFF
--- a/src/whitenoise/base.py
+++ b/src/whitenoise/base.py
@@ -106,7 +106,7 @@ class WhiteNoise:
             if os.path.isdir(root):
                 self.update_files_dictionary(root, prefix)
             else:
-                warnings.warn(f"No directory at: {root}")
+                warnings.warn(f"No directory at: {root}", stacklevel=3)
 
     def update_files_dictionary(self, root, prefix):
         # Build a mapping from paths to the results of `os.stat` calls


### PR DESCRIPTION
New flake8-bugbear check:

B028 No explicit stacklevel keyword argument found. The warn method from the warnings module uses a stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called. It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.