### PR TITLE
Compress each file in a ThreadPool

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,11 @@ Unreleased
 
   Thanks to Sarah Boyce in `PR #486 <https://github.com/evansd/whitenoise/pull/486>`__.
 
+* Compress files using a thread pool.
+  This speeds up the compression step up to four times in benchmarks.
+
+  Thanks to Anthony Ricaud in `PR #484 <https://github.com/evansd/whitenoise/pull/484>`__.
+
 6.7.0 (2024-06-19)
 ------------------
 

--- a/src/whitenoise/storage.py
+++ b/src/whitenoise/storage.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-import concurrent.futures
 import errno
 import os
 import re
 import textwrap
+from collections.abc import Generator
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
 from typing import Any
 from typing import Union
 
@@ -32,22 +34,21 @@ class CompressedStaticFilesStorage(StaticFilesStorage):
         extensions = getattr(settings, "WHITENOISE_SKIP_COMPRESS_EXTENSIONS", None)
         self.compressor = self.create_compressor(extensions=extensions, quiet=True)
 
-        to_compress = (path for path in paths if self.compressor.should_compress(path))
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures = (
-                executor.submit(self._compress_one, path) for path in to_compress
-            )
-            for compressed_paths in concurrent.futures.as_completed(futures):
-                yield from compressed_paths.result()
+        def _compress_path(path: str) -> Generator[tuple[str, str, bool]]:
+            full_path = self.path(path)
+            prefix_len = len(full_path) - len(path)
+            for compressed_path in self.compressor.compress(full_path):
+                compressed_name = compressed_path[prefix_len:]
+                yield (path, compressed_name, True)
 
-    def _compress_one(self, path: str) -> list[tuple[str, str, bool]]:
-        compressed: list[tuple[str, str, bool]] = []
-        full_path = self.path(path)
-        prefix_len = len(full_path) - len(path)
-        for compressed_path in self.compressor.compress(full_path):
-            compressed_name = compressed_path[prefix_len:]
-            compressed.append((path, compressed_name, True))
-        return compressed
+        with ThreadPoolExecutor() as executor:
+            futures = (
+                executor.submit(_compress_path, path)
+                for path in paths
+                if self.compressor.should_compress(path)
+            )
+            for future in as_completed(futures):
+                yield from future.result()
 
     def create_compressor(self, **kwargs: Any) -> Compressor:
         return Compressor(**kwargs)
@@ -137,26 +138,25 @@ class CompressedManifestStaticFilesStorage(ManifestStaticFilesStorage):
     def create_compressor(self, **kwargs):
         return Compressor(**kwargs)
 
-    def compress_files(self, names):
+    def compress_files(self, paths):
         extensions = getattr(settings, "WHITENOISE_SKIP_COMPRESS_EXTENSIONS", None)
         self.compressor = self.create_compressor(extensions=extensions, quiet=True)
 
-        to_compress = (name for name in names if self.compressor.should_compress(name))
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures = (
-                executor.submit(self._compress_one, name) for name in to_compress
-            )
-            for compressed_paths in concurrent.futures.as_completed(futures):
-                yield from compressed_paths.result()
+        def _compress_path(path: str) -> Generator[tuple[str, str]]:
+            full_path = self.path(path)
+            prefix_len = len(full_path) - len(path)
+            for compressed_path in self.compressor.compress(full_path):
+                compressed_name = compressed_path[prefix_len:]
+                yield (path, compressed_name)
 
-    def _compress_one(self, name: str) -> list[tuple[str, str]]:
-        compressed: list[tuple[str, str]] = []
-        path = self.path(name)
-        prefix_len = len(path) - len(name)
-        for compressed_path in self.compressor.compress(path):
-            compressed_name = compressed_path[prefix_len:]
-            compressed.append((name, compressed_name))
-        return compressed
+        with ThreadPoolExecutor() as executor:
+            futures = (
+                executor.submit(_compress_path, path)
+                for path in paths
+                if self.compressor.should_compress(path)
+            )
+            for future in as_completed(futures):
+                yield from future.result()
 
     def make_helpful_exception(self, exception, name):
         """

--- a/src/whitenoise/storage.py
+++ b/src/whitenoise/storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import concurrent.futures
 import errno
 import os
 import re
@@ -29,15 +30,24 @@ class CompressedStaticFilesStorage(StaticFilesStorage):
             return
 
         extensions = getattr(settings, "WHITENOISE_SKIP_COMPRESS_EXTENSIONS", None)
-        compressor = self.create_compressor(extensions=extensions, quiet=True)
+        self.compressor = self.create_compressor(extensions=extensions, quiet=True)
 
-        for path in paths:
-            if compressor.should_compress(path):
-                full_path = self.path(path)
-                prefix_len = len(full_path) - len(path)
-                for compressed_path in compressor.compress(full_path):
-                    compressed_name = compressed_path[prefix_len:]
-                    yield path, compressed_name, True
+        to_compress = (path for path in paths if self.compressor.should_compress(path))
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures = (
+                executor.submit(self._compress_one, path) for path in to_compress
+            )
+            for compressed_paths in concurrent.futures.as_completed(futures):
+                yield from compressed_paths.result()
+
+    def _compress_one(self, path: str) -> list[tuple[str, str, bool]]:
+        compressed: list[tuple[str, str, bool]] = []
+        full_path = self.path(path)
+        prefix_len = len(full_path) - len(path)
+        for compressed_path in self.compressor.compress(full_path):
+            compressed_name = compressed_path[prefix_len:]
+            compressed.append((path, compressed_name, True))
+        return compressed
 
     def create_compressor(self, **kwargs: Any) -> Compressor:
         return Compressor(**kwargs)
@@ -129,14 +139,24 @@ class CompressedManifestStaticFilesStorage(ManifestStaticFilesStorage):
 
     def compress_files(self, names):
         extensions = getattr(settings, "WHITENOISE_SKIP_COMPRESS_EXTENSIONS", None)
-        compressor = self.create_compressor(extensions=extensions, quiet=True)
-        for name in names:
-            if compressor.should_compress(name):
-                path = self.path(name)
-                prefix_len = len(path) - len(name)
-                for compressed_path in compressor.compress(path):
-                    compressed_name = compressed_path[prefix_len:]
-                    yield name, compressed_name
+        self.compressor = self.create_compressor(extensions=extensions, quiet=True)
+
+        to_compress = (name for name in names if self.compressor.should_compress(name))
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            futures = (
+                executor.submit(self._compress_one, name) for name in to_compress
+            )
+            for compressed_paths in concurrent.futures.as_completed(futures):
+                yield from compressed_paths.result()
+
+    def _compress_one(self, name: str) -> list[tuple[str, str]]:
+        compressed: list[tuple[str, str]] = []
+        path = self.path(name)
+        prefix_len = len(path) - len(name)
+        for compressed_path in self.compressor.compress(path):
+            compressed_name = compressed_path[prefix_len:]
+            compressed.append((name, compressed_name))
+        return compressed
 
     def make_helpful_exception(self, exception, name):
         """


### PR DESCRIPTION
fix https://github.com/evansd/whitenoise/issues/148

---

I've tested this on a 2020 M1 MacBook Air (4 big + 4 small cores). In milliseconds.

Executable    | Files | Brotli | Sequential | Parallel | Win
------------- | ----: | :----: | ---------: | -------: | --:
CLI           |  4656 | No     |       3190 |     1050 | 3.0x
CLI           |  4656 | Yes    |      78800 |    17630 | 4.2x
CLI           |   783 | No     |        674 |      299 | 2.2x
CLI           |   783 | Yes    |      10740 |     3630 | 2.9x
collectstatic |  4656 | No     |       8860 |     6790 | 1.3x
collectstatic |  4656 | Yes    |      82410 |    25110 | 3.3x
collectstatic |   783 | No     |       1510 |     1370 | 1.1x
collectstatic |   783 | Yes    |      11370 |     5120 | 2.2x

<details><summary>Commands to test yourself</summary>

- CLI without Brotli
  ```sh
  time python -m whitenoise.compress --quiet --no-brotli staticfiles
  ```
- CLI with Brotli
  ```sh
  time python -m whitenoise.compress --quiet staticfiles
  ```
- collectstatic without Brotli
  ```sh
  rm -rf staticfiles/; pip uninstall brotli --yes; time ./manage.py collectstatic --no-input
  ```
- collectstatic with Brotli
  ```sh
  rm -rf staticfiles/; pip install brotli; time ./manage.py collectstatic --no-input
  ```
</details>