### PR TITLE
Use settings.FORCE_SCRIPT_NAME correctly

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,9 +16,13 @@ Unreleased
   Thanks to Per Myren for the detailed investigation and fix in `PR #612 <https://github.com/evansd/whitenoise/pull/612>`__.
 
 * Respect the Django setting |FORCE_SCRIPT_NAME|__.
+  This reverts a change from version 5.3.0 that added a call to Django’s |get_script_prefix() method|__ outside of the request-response cycle.
 
   .. |FORCE_SCRIPT_NAME| replace:: ``FORCE_SCRIPT_NAME``
   __ https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-FORCE_SCRIPT_NAME
+
+  .. |get_script_prefix() method| replace:: ``get_script_prefix()`` method
+  __ https://docs.djangoproject.com/en/stable/ref/urlresolvers/#django.urls.get_script_prefix
 
   Thanks to Sarah Boyce in `PR #486 <https://github.com/evansd/whitenoise/pull/486>`__.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,13 @@ Unreleased
 
   Thanks to Per Myren for the detailed investigation and fix in `PR #612 <https://github.com/evansd/whitenoise/pull/612>`__.
 
+* Respect the Django setting |FORCE_SCRIPT_NAME|__.
+
+  .. |FORCE_SCRIPT_NAME| replace:: ``FORCE_SCRIPT_NAME``
+  __ https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-FORCE_SCRIPT_NAME
+
+  Thanks to Sarah Boyce in `PR #486 <https://github.com/evansd/whitenoise/pull/486>`__.
+
 6.7.0 (2024-06-19)
 ------------------
 
@@ -33,11 +40,6 @@ Unreleased
 * Support Python 3.12.
 
 * Changed documentation site URL from ``https://whitenoise.evans.io/`` to ``https://whitenoise.readthedocs.io/``.
-
-6.5.0 (unreleased)
-------------------
-
-* Handle the Django setting ``FORCE_SCRIPT_NAME``.
 
 6.4.0 (2023-02-25)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,11 @@ Unreleased
 
 * Changed documentation site URL from ``https://whitenoise.evans.io/`` to ``https://whitenoise.readthedocs.io/``.
 
+6.5.0 (unreleased)
+------------------
+
+* Handle the Django setting ``FORCE_SCRIPT_NAME``.
+
 6.4.0 (2023-02-25)
 ------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ Unreleased
 
   Thanks to Per Myren for the detailed investigation and fix in `PR #612 <https://github.com/evansd/whitenoise/pull/612>`__.
 
-* Respect the Django setting |FORCE_SCRIPT_NAME|__.
+* Use Django’s |FORCE_SCRIPT_NAME|__ setting correctly.
   This reverts a change from version 5.3.0 that added a call to Django’s |get_script_prefix() method|__ outside of the request-response cycle.
 
   .. |FORCE_SCRIPT_NAME| replace:: ``FORCE_SCRIPT_NAME``

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -460,8 +460,10 @@ arguments upper-cased with a 'WHITENOISE\_' prefix.
     then ``WHITENOISE_STATIC_PREFIX`` will be ``/static/``.
 
     If your application is not running at the root of the domain and
-    ``FORCE_SCRIPT_NAME`` is set then this value will be removed from the
-    ``STATIC_URL`` path first to give the correct prefix.
+    ``FORCE_SCRIPT_NAME`` is set, then this value will be removed from the
+    ``STATIC_URL`` path first, to give the correct prefix. For example, if
+    ``STATIC_URL`` is ``'apple/static/`` and ``FORCE_SCRIPT_NAME`` is
+    ``'/apple'``, then ``WHITENOISE_STATIC_PREFIX`` will be ``/static/``.
 
     If your deployment is more complicated than this (for instance, if you are
     using a CDN which is doing path rewriting) then you may need to configure

--- a/src/whitenoise/middleware.py
+++ b/src/whitenoise/middleware.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import FileResponse
-from django.urls import get_script_prefix
 
 from whitenoise.base import WhiteNoise
 from whitenoise.string_utils import ensure_leading_trailing_slash
@@ -94,10 +93,10 @@ class WhiteNoiseMiddleware(WhiteNoise):
             self.static_prefix = settings.WHITENOISE_STATIC_PREFIX
         except AttributeError:
             self.static_prefix = urlparse(settings.STATIC_URL or "").path
-            script_prefix = get_script_prefix().rstrip("/")
-            if script_prefix:
-                if self.static_prefix.startswith(script_prefix):
-                    self.static_prefix = self.static_prefix[len(script_prefix) :]
+            if settings.FORCE_SCRIPT_NAME:
+                script_name = settings.FORCE_SCRIPT_NAME.rstrip("/")
+                if self.static_prefix.startswith(script_name):
+                    self.static_prefix = self.static_prefix[len(script_name) :]
         self.static_prefix = ensure_leading_trailing_slash(self.static_prefix)
 
         self.static_root = settings.STATIC_ROOT

--- a/tests/test_django_whitenoise.py
+++ b/tests/test_django_whitenoise.py
@@ -211,10 +211,9 @@ def test_relative_static_url(server, static_files, _collect_static):
         assert response.content == static_files.js_content
 
 
+@override_settings(FORCE_SCRIPT_NAME="/subdir", STATIC_URL="static/")
 def test_force_script_name(server, static_files, _collect_static):
-    with override_settings(
-        FORCE_SCRIPT_NAME="/forced_script_name", STATIC_URL="static/"
-    ):
-        url = storage.staticfiles_storage.url(static_files.js_path)
-        response = server.get(url)
-        assert response.content == static_files.js_content
+    url = storage.staticfiles_storage.url(static_files.js_path)
+    assert url.startswith("/subdir/static/")
+    response = server.get(url)
+    assert response.content == static_files.js_content

--- a/tests/test_django_whitenoise.py
+++ b/tests/test_django_whitenoise.py
@@ -209,3 +209,12 @@ def test_relative_static_url(server, static_files, _collect_static):
         url = storage.staticfiles_storage.url(static_files.js_path)
         response = server.get(url)
         assert response.content == static_files.js_content
+
+
+def test_force_script_name(server, static_files, _collect_static):
+    with override_settings(
+        FORCE_SCRIPT_NAME="/forced_script_name", STATIC_URL="static/"
+    ):
+        url = storage.staticfiles_storage.url(static_files.js_path)
+        response = server.get(url)
+        assert response.content == static_files.js_content


### PR DESCRIPTION
Hello :wave: 

This reverts this change https://github.com/evansd/whitenoise/pull/259 which added the use of `get_script_prefix` in the middleware init. 
Unfortunately this function is not designed to be used outside the request response cycle and as middleware is initialised outside of that, this is causing unexpected results. For now reverting this change is the best solution to resolve this issue https://github.com/evansd/whitenoise/issues/271  :+1: 

Note: You can see [here](https://github.com/django/django/pull/16714#discussion_r1156834258) a suggestion to have a better way to access this outside the request response cycle is being discussed