### PR TITLE
Use only absolute imports

### DIFF
--- a/src/whitenoise/__init__.py
+++ b/src/whitenoise/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from .base import WhiteNoise
+from whitenoise.base import WhiteNoise
 
 __all__ = ["WhiteNoise"]

--- a/src/whitenoise/base.py
+++ b/src/whitenoise/base.py
@@ -8,13 +8,13 @@ from typing import Callable
 from wsgiref.headers import Headers
 from wsgiref.util import FileWrapper
 
-from .media_types import MediaTypes
-from .responders import IsDirectoryError
-from .responders import MissingFileError
-from .responders import Redirect
-from .responders import StaticFile
-from .string_utils import decode_path_info
-from .string_utils import ensure_leading_trailing_slash
+from whitenoise.media_types import MediaTypes
+from whitenoise.responders import IsDirectoryError
+from whitenoise.responders import MissingFileError
+from whitenoise.responders import Redirect
+from whitenoise.responders import StaticFile
+from whitenoise.string_utils import decode_path_info
+from whitenoise.string_utils import ensure_leading_trailing_slash
 
 
 class WhiteNoise:

--- a/src/whitenoise/middleware.py
+++ b/src/whitenoise/middleware.py
@@ -10,8 +10,8 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import FileResponse
 from django.urls import get_script_prefix
 
-from .base import WhiteNoise
-from .string_utils import ensure_leading_trailing_slash
+from whitenoise.base import WhiteNoise
+from whitenoise.string_utils import ensure_leading_trailing_slash
 
 __all__ = ["WhiteNoiseMiddleware"]
 

--- a/src/whitenoise/storage.py
+++ b/src/whitenoise/storage.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
 from django.contrib.staticfiles.storage import StaticFilesStorage
 
-from .compress import Compressor
+from whitenoise.compress import Compressor
 
 _PostProcessT = Iterator[Union[Tuple[str, str, bool], Tuple[str, None, RuntimeError]]]
 

--- a/tests/django_settings.py
+++ b/tests/django_settings.py
@@ -4,8 +4,8 @@ import os.path
 
 import django
 
-from .utils import AppServer
-from .utils import TEST_FILE_PATH
+from whitenoise.utils import AppServer
+from whitenoise.utils import TEST_FILE_PATH
 
 ALLOWED_HOSTS = ["*"]
 

--- a/tests/django_settings.py
+++ b/tests/django_settings.py
@@ -4,8 +4,8 @@ import os.path
 
 import django
 
-from whitenoise.utils import AppServer
-from whitenoise.utils import TEST_FILE_PATH
+from tests.utils import AppServer
+from tests.utils import TEST_FILE_PATH
 
 ALLOWED_HOSTS = ["*"]
 

--- a/tests/test_django_whitenoise.py
+++ b/tests/test_django_whitenoise.py
@@ -15,10 +15,10 @@ from django.core.wsgi import get_wsgi_application
 from django.test.utils import override_settings
 from django.utils.functional import empty
 
+from tests.utils import AppServer
+from tests.utils import Files
 from whitenoise.middleware import WhiteNoiseFileResponse
 from whitenoise.middleware import WhiteNoiseMiddleware
-from whitenoise.utils import AppServer
-from whitenoise.utils import Files
 
 
 def reset_lazy_object(obj):

--- a/tests/test_django_whitenoise.py
+++ b/tests/test_django_whitenoise.py
@@ -15,10 +15,10 @@ from django.core.wsgi import get_wsgi_application
 from django.test.utils import override_settings
 from django.utils.functional import empty
 
-from .utils import AppServer
-from .utils import Files
 from whitenoise.middleware import WhiteNoiseFileResponse
 from whitenoise.middleware import WhiteNoiseMiddleware
+from whitenoise.utils import AppServer
+from whitenoise.utils import Files
 
 
 def reset_lazy_object(obj):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -15,9 +15,9 @@ from django.core.management import call_command
 from django.test.utils import override_settings
 from django.utils.functional import empty
 
+from tests.utils import Files
 from whitenoise.storage import CompressedManifestStaticFilesStorage
 from whitenoise.storage import MissingFileError
-from whitenoise.utils import Files
 
 
 @pytest.fixture()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -15,9 +15,9 @@ from django.core.management import call_command
 from django.test.utils import override_settings
 from django.utils.functional import empty
 
-from .utils import Files
 from whitenoise.storage import CompressedManifestStaticFilesStorage
 from whitenoise.storage import MissingFileError
+from whitenoise.utils import Files
 
 
 @pytest.fixture()

--- a/tests/test_whitenoise.py
+++ b/tests/test_whitenoise.py
@@ -14,10 +14,10 @@ from wsgiref.simple_server import demo_app
 
 import pytest
 
-from .utils import AppServer
-from .utils import Files
 from whitenoise import WhiteNoise
 from whitenoise.responders import StaticFile
+from whitenoise.utils import AppServer
+from whitenoise.utils import Files
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_whitenoise.py
+++ b/tests/test_whitenoise.py
@@ -14,10 +14,10 @@ from wsgiref.simple_server import demo_app
 
 import pytest
 
+from tests.utils import AppServer
+from tests.utils import Files
 from whitenoise import WhiteNoise
 from whitenoise.responders import StaticFile
-from whitenoise.utils import AppServer
-from whitenoise.utils import Files
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
They’re easier to understand as they require no mental computation to parse.