### PR TITLE
Upgrade and clarify Django quickstart docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,14 +60,19 @@ list, above all other middleware apart from Django's `SecurityMiddleware
 
 That's it, you're ready to go.
 
-Want forever-cacheable files and compression support? Just add this to your
+Want forever-cacheable files and compression support? On Django 4.2+, just add this to your
 ``settings.py``:
 
 .. code-block:: python
 
-   STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+   STORAGES = {
+       # ...
+       "staticfiles": {
+           "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+       },
+   }
 
-For more details, including on setting up
+For older Django versions and more details, including on setting up
 CloudFront and other CDNs see the :doc:`Using WhiteNoise with Django <django>`
 guide.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,8 +60,8 @@ list, above all other middleware apart from Django's `SecurityMiddleware
 
 That's it, you're ready to go.
 
-Want forever-cacheable files and compression support? On Django 4.2+, just add this to your
-``settings.py``:
+Want forever-cacheable files and compression support? Just add this to your
+settings file:
 
 .. code-block:: python
 
@@ -72,7 +72,7 @@ Want forever-cacheable files and compression support? On Django 4.2+, just add t
        },
    }
 
-For older Django versions and more details, including on setting up
+For more details, including on setting up
 CloudFront and other CDNs see the :doc:`Using WhiteNoise with Django <django>`
 guide.
 


### PR DESCRIPTION
Hello!

Django latest release is 5.0. After 4.2 the way of configuring compression and caching content has changed, as you are already commenting on the specific Django section ( https://github.com/evansd/whitenoise/blob/main/docs/django.rst ). I've updated also the quickstart by first mentioning the new style but also referring to search for more information for older versions, since I felt it could be misleading like it is now.

I hope you find it useful. Thanks.