### PR TITLE
Move CI to Ubuntu 24.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-22.04
+        - ubuntu-24.04
         - windows-2022
         python-version:
         - '3.8'
@@ -54,7 +54,7 @@ jobs:
 
   coverage:
     name: Coverage
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: tests
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Currently in beta (see https://github.com/actions/runner-images) but should be stable enough for us.
