### PR TITLE
Add license identifier to project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ readme = "README.rst"
 keywords = [
   "Django",
 ]
+license = { text = "MIT" }
 maintainers = [
   { name = "Adam Johnson", email = "me@adamj.eu" },
   { name = "David Evans" },


### PR DESCRIPTION
License scanning tools (such as the one used by GitLab) rely on the project metadata (made available via the PyPi API) to detect the license for a package.

Currently, `license: null` is returned.

This PR adds the license to the project metadata.