### PR TITLE
Preserve query string on redirect

### DIFF
--- a/src/whitenoise/responders.py
+++ b/src/whitenoise/responders.py
@@ -239,6 +239,13 @@ class Redirect:
         self.response = Response(HTTPStatus.FOUND, headers, None)
 
     def get_response(self, method, request_headers):
+        query_string = request_headers.get("QUERY_STRING")
+        if query_string:
+            headers = list(self.response.headers)
+            name, value = headers[-1]
+            value = "%s?%s" % (value, query_string)
+            headers[-1] = (name, value)
+            return Response(self.response.status, headers, None)
         return self.response
 
 


### PR DESCRIPTION
Hi there :wave:

On one of my Django projects, I got tripped up by whitenoise stripping query strings on redirect, so for example `/foo?bar=baz` redirects to `/foo/` when I was expecting it to instead redirect to `/foo/?bar=baz`. Would you be open to merging a patch that preserves the query string on redirect?

I'm opening a pull request to show what an implementation could look like and to start the discussion. If you're happy with the proposal, I can work on putting the functionality behind a setting (to not break backwards compatibility), unit tests, and what-ever else is needed.

Thanks for your time!