### PR TITLE
Make sure SlicedFile is closed properly

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,10 @@ Unreleased
 
 * Support Python 3.13.
 
+* Fix a bug introduced in version 6.0.0 where ``Range`` requests could lead to database connection errors in other requests.
+
+  Thanks to Per Myren for the detailed investigation and fix in `PR #612 <https://github.com/evansd/whitenoise/pull/612>`__.
+
 6.7.0 (2024-06-19)
 ------------------
 

--- a/src/whitenoise/responders.py
+++ b/src/whitenoise/responders.py
@@ -64,6 +64,7 @@ class SlicedFile(BufferedIOBase):
         return data
 
     def close(self):
+        super().close()
         self.fileobj.close()
 
 

--- a/tests/test_responders.py
+++ b/tests/test_responders.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+from django.test import SimpleTestCase
+
+from whitenoise.responders import SlicedFile
+
+
+class SlicedFileTests(SimpleTestCase):
+    def test_close_does_not_rerun_on_del(self):
+        """
+        Regression test for the subtle close() behaviour of SlicedFile that
+        could lead to database connection errors.
+
+        https://github.com/evansd/whitenoise/pull/612
+        """
+        file = BytesIO(b"1234567890")
+        sliced_file = SlicedFile(file, 1, 2)
+
+        # Emulate how Django patches the file object's close() method to be
+        # response.close() and count the calls.
+        # https://github.com/django/django/blob/345a6652e6a15febbf4f68351dcea5dd674ea324/django/core/handlers/wsgi.py#L137-L140
+        calls = 0
+
+        file_close = sliced_file.close
+
+        def closer():
+            nonlocal calls, file_close
+            calls += 1
+            if file_close is not None:
+                file_close()
+                file_close = None
+
+        sliced_file.close = closer
+
+        sliced_file.close()
+        assert calls == 1
+
+        # Deleting the sliced file should not call close again.
+        del sliced_file
+        assert calls == 1


### PR DESCRIPTION
Fixes #556

This is what causing the issue:

When django processes the file response it will replace the file.close method with the response.close method:
https://github.com/django/django/blob/345a6652e6a15febbf4f68351dcea5dd674ea324/django/core/handlers/wsgi.py#L140

If the super().close method is not called from SlicedFile, the destructor IOBase will call the close method: 
https://github.com/python/cpython/blob/9a22ec735fb2f0ec850e70dd119e8422c97567e5/Lib/_pyio.py#L407

Because Django replaced the IOBase.close method with the response.close method, this will cause the response close method to be called twice, which can happen in the middle of processing another request:
https://github.com/django/django/blob/3fad712a91a8a8f6f6f904aff3d895e3b06b24c7/django/http/response.py#L336

This fires off the `signals.request_finished` which can cause the database connection to be closed in the middle of processing a request:
https://github.com/django/django/blob/3fad712a91a8a8f6f6f904aff3d895e3b06b24c7/django/db/__init__.py#L57
