### PR TITLE
Add license to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires = [
 name = "whitenoise"
 version = "6.8.2"
 description = "Radically simplified static file serving for WSGI applications"
+license = {text = "MIT"}
 readme = "README.rst"
 keywords = [
   "Django",


### PR DESCRIPTION
Add the current license to the `project` section in the `pyproject.toml` file.

Recommended by Poetry:
[Poetry docs](https://python-poetry.org/docs/pyproject/#license)
[Python Packaging User Guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license)
