### PR TITLE
Remove documentation note on old request_finished bug

### DIFF
--- a/docs/django.rst
+++ b/docs/django.rst
@@ -70,10 +70,7 @@ caching.
 .. note:: You might find other third-party middleware that suggests it should
    be given highest priority at the top of the middleware list. Unless you
    understand exactly what is happening you should ignore this advice and always
-   place ``WhiteNoiseMiddleware`` above other middleware. If you plan to have other
-   middleware run before WhiteNoise you should be aware of the
-   `request_finished bug <https://code.djangoproject.com/ticket/29069>`_ in
-   Django.
+   place ``WhiteNoiseMiddleware`` above other middleware.
 
 
 .. _compression-and-caching:


### PR DESCRIPTION
I don't think the comment re: the `request_finished` bug ([#29069](https://code.djangoproject.com/ticket/29069)) in the Django page of the docs is still relevant as this bug was closed five years ago and the fix released in Django 3.0.4.

PS. doesn't seem like this project currently follows Conventional Commits - happy to amend the commit message.