### PR TITLE
Add sphinx-build-compatibility for Read the Docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ release = version
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.extlinks",
+    "sphinx_build_compatibility.extension",
     "sphinx_copybutton",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ test = [
 docs = [
   "furo>=2024.8.6",
   "sphinx>=7.4.7",
+  "sphinx-build-compatibility",
   "sphinx-copybutton>=0.5.2",
 ]
 
@@ -144,3 +145,6 @@ conflicts = [
     { group = "django52" },
   ],
 ]
+
+[tool.uv.sources]
+sphinx-build-compatibility = { git = "https://github.com/readthedocs/sphinx-build-compatibility" }

--- a/uv.lock
+++ b/uv.lock
@@ -768,6 +768,17 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-build-compatibility"
+version = "0.0.1"
+source = { git = "https://github.com/readthedocs/sphinx-build-compatibility#58aabc5f207c6c2421f23d3578adc0b14af57047" }
+dependencies = [
+    { name = "requests" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django50') or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django51') or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django52') or (extra == 'group-10-whitenoise-django50' and extra == 'group-10-whitenoise-django51') or (extra == 'group-10-whitenoise-django50' and extra == 'group-10-whitenoise-django52') or (extra == 'group-10-whitenoise-django51' and extra == 'group-10-whitenoise-django52')" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django50') or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django51') or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django52') or (extra == 'group-10-whitenoise-django50' and extra == 'group-10-whitenoise-django51') or (extra == 'group-10-whitenoise-django50' and extra == 'group-10-whitenoise-django52') or (extra == 'group-10-whitenoise-django51' and extra == 'group-10-whitenoise-django52')" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django50') or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django51') or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django52') or (extra == 'group-10-whitenoise-django50' and extra == 'group-10-whitenoise-django51') or (extra == 'group-10-whitenoise-django50' and extra == 'group-10-whitenoise-django52') or (extra == 'group-10-whitenoise-django51' and extra == 'group-10-whitenoise-django52')" },
+]
+
+[[package]]
 name = "sphinx-copybutton"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -938,6 +949,7 @@ docs = [
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django50') or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django51') or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django52') or (extra == 'group-10-whitenoise-django50' and extra == 'group-10-whitenoise-django51') or (extra == 'group-10-whitenoise-django50' and extra == 'group-10-whitenoise-django52') or (extra == 'group-10-whitenoise-django51' and extra == 'group-10-whitenoise-django52')" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django50') or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django51') or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django52') or (extra == 'group-10-whitenoise-django50' and extra == 'group-10-whitenoise-django51') or (extra == 'group-10-whitenoise-django50' and extra == 'group-10-whitenoise-django52') or (extra == 'group-10-whitenoise-django51' and extra == 'group-10-whitenoise-django52')" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django50') or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django51') or (extra == 'group-10-whitenoise-django42' and extra == 'group-10-whitenoise-django52') or (extra == 'group-10-whitenoise-django50' and extra == 'group-10-whitenoise-django51') or (extra == 'group-10-whitenoise-django50' and extra == 'group-10-whitenoise-django52') or (extra == 'group-10-whitenoise-django51' and extra == 'group-10-whitenoise-django52')" },
+    { name = "sphinx-build-compatibility" },
     { name = "sphinx-copybutton" },
 ]
 test = [
@@ -964,6 +976,7 @@ django52 = [{ name = "django", marker = "python_full_version >= '3.10'", specifi
 docs = [
     { name = "furo", specifier = ">=2024.8.6" },
     { name = "sphinx", specifier = ">=7.4.7" },
+    { name = "sphinx-build-compatibility", git = "https://github.com/readthedocs/sphinx-build-compatibility" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
 ]
 test = [


### PR DESCRIPTION
This is a workaround to restore some features, like the GitHub link, until Furo updates to deal with the new RtD environment: https://github.com/pradyunsg/furo/issues/795.