### PR TITLE
Fail coverage GHA job when tests fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,10 @@ jobs:
     needs: tests
     if: always()
     steps:
+    - name: Check all test jobs passed
+      if: needs.tests.result != 'success'
+      run: exit 1
+
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false


### PR DESCRIPTION
Add an explicit guard to ensure that the coverage job fails if the tests fail, so that if only some tests fail but coverage remains 100%, the required coverage job does not complete.
