### PR TITLE
Document Django 6.1 support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ WhiteNoise works with any WSGI-compatible application.
 
 Python 3.8 to 3.14 supported.
 
-Django 4.2 to 6.0 supported.
+Django 4.2 to 6.1 supported.
 
 Installation
 ------------


### PR DESCRIPTION
Missed in #702 because my upgrade script didn't edit `docs/index.rst`.