### PR TITLE
fix(storage): strip query strings from hashed_name tracking (#690)

### DIFF
--- a/src/whitenoise/storage.py
+++ b/src/whitenoise/storage.py
@@ -115,7 +115,12 @@ class CompressedManifestStaticFilesStorage(ManifestStaticFilesStorage):
     def hashed_name(self, *args, **kwargs):
         name = super().hashed_name(*args, **kwargs)
         if self._new_files is not None:
-            self._new_files.add(self.clean_name(name))
+            # Strip any query-string tail (e.g. "?v=4.0.3") before tracking.
+            # CSS url() references may include query strings for cache-busting,
+            # but these are URL-only; the actual file on disk has no "?" in its
+            # path. On Windows, "?" is an illegal filename character and causes
+            # OSError [WinError 123] when delete_files() tries to unlink it.
+            self._new_files.add(self.clean_name(name).split("?")[0])
         return name
 
     def start_tracking_new_files(self, new_files):


### PR DESCRIPTION
## Problem

Fixes #690.

`collectstatic` crashes on Windows with `OSError: [WinError 123]` when a CSS file contains `url()` references with query strings (e.g. `?v=4.0.3` cache-busters) and `WHITENOISE_KEEP_ONLY_HASHED_FILES = True`:

```
OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect:
'...staticfiles\rest_framework\fonts\fontawesome-webfont.dcb26c7239d8.ttf?v=4.0.3'
```

Setting works fine without `WHITENOISE_KEEP_ONLY_HASHED_FILES = True`.

## Root Cause

In `post_process_with_compression`, whitenoise tracks intermediate hashed filenames through the `hashed_name()` override:

```python
def hashed_name(self, *args, **kwargs):
    name = super().hashed_name(*args, **kwargs)
    if self._new_files is not None:
        self._new_files.add(self.clean_name(name))  # may include ?v=4.0.3
    return name
```

In Django 6.x, `super().hashed_name()` processes CSS `url()` references and may return names that preserve the query string from the source URL (e.g. `fonts/fontawesome-webfont.dcb26c7239d8.ttf?v=4.0.3`).

However, Django's `post_process()` yields tuples using the clean file path (without query string), so `hashed_files` gets the clean variant while `new_files` gets the `?v=4.0.3` variant. The set difference:

```python
files_to_delete = (original_files | new_files) - hashed_files
```

retains the query-string variant in `files_to_delete`, and then:

```python
os.unlink(self.path("...fontawesome-webfont.dcb26c7239d8.ttf?v=4.0.3"))
```

fails on Windows because `?` is an illegal filename character.

**With `WHITENOISE_KEEP_ONLY_HASHED_FILES = False`**, `delete_files()` is never called, so the bad path never reaches `os.unlink()` — which explains why that setting sidesteps the crash.

## Fix

Strip the query string before adding the name to `_new_files`. A `?` in a file path is always a URL artifact — files on disk never contain `?` in their name.

```diff
 def hashed_name(self, *args, **kwargs):
     name = super().hashed_name(*args, **kwargs)
     if self._new_files is not None:
-        self._new_files.add(self.clean_name(name))
+        self._new_files.add(self.clean_name(name).split("?")[0])
     return name
```

## Impact

| Scenario | Before | After |
|---|---|---|
| CSS with `url('font.ttf?v=1.0')`, `KEEP_ONLY_HASHED=True`, Windows | `OSError [WinError 123]` | Works ✓ |
| CSS with `url('font.ttf?v=1.0')`, `KEEP_ONLY_HASHED=True`, Linux | Works (no error, wrong delete attempt) | Works ✓ |
| CSS with plain `url('font.ttf')` | Unchanged ✓ | Unchanged ✓ |
| `KEEP_ONLY_HASHED=False` | Unchanged ✓ | Unchanged ✓ |
