### PR TITLE
Remove sphinx-build-compatibility

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-import os
 import sys
 from pathlib import Path
 
@@ -36,8 +35,6 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx_copybutton",
 ]
-if os.environ.get("READTHEDOCS") == "True":
-    extensions.append("sphinx_build_compatibility.extension")
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -76,6 +73,9 @@ html_theme_options = {
         "admonition-font-size": "100%",
         "admonition-title-font-size": "100%",
     },
+    "source_repository": "https://github.com/evansd/whitenoise/",
+    "source_branch": "main",
+    "source_directory": "docs/",
 }
 
 # Output file base name for HTML help builder.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ test = [
 docs = [
   "furo>=2024.8.6",
   "sphinx>=7.4.7",
-  "sphinx-build-compatibility",
   "sphinx-copybutton>=0.5.2",
 ]
 django52 = [ "django>=5.2a1,<6; python_version>='3.10'" ]
@@ -66,7 +65,6 @@ django60 = [ "django>=6a1,<6.1; python_version>='3.12'" ]
 django61 = [ "django>=6.1a1,<6.2; python_version>='3.12'" ]
 
 [tool.uv]
-sources.sphinx-build-compatibility = { git = "https://github.com/readthedocs/sphinx-build-compatibility", rev = "4f304bd4562cdc96316f4fec82b264ca379d23e0" }
 conflicts = [
   [
     { group = "django52" },

--- a/uv.lock
+++ b/uv.lock
@@ -338,9 +338,9 @@ name = "django"
 version = "5.2.16"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
+    "python_full_version >= '3.12'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
-    "python_full_version >= '3.12'",
 ]
 dependencies = [
     { name = "asgiref", marker = "python_full_version < '3.12' or extra == 'group-10-whitenoise-django52' or (extra == 'group-10-whitenoise-django60' and extra == 'group-10-whitenoise-django61')" },
@@ -772,17 +772,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sphinx-build-compatibility"
-version = "0.0.1"
-source = { git = "https://github.com/readthedocs/sphinx-build-compatibility?rev=4f304bd4562cdc96316f4fec82b264ca379d23e0#4f304bd4562cdc96316f4fec82b264ca379d23e0" }
-dependencies = [
-    { name = "requests" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'group-10-whitenoise-django52' and extra == 'group-10-whitenoise-django60') or (extra == 'group-10-whitenoise-django52' and extra == 'group-10-whitenoise-django61') or (extra == 'group-10-whitenoise-django60' and extra == 'group-10-whitenoise-django61')" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'group-10-whitenoise-django52' and extra == 'group-10-whitenoise-django60') or (extra == 'group-10-whitenoise-django52' and extra == 'group-10-whitenoise-django61') or (extra == 'group-10-whitenoise-django60' and extra == 'group-10-whitenoise-django61')" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'group-10-whitenoise-django52' and extra == 'group-10-whitenoise-django60') or (extra == 'group-10-whitenoise-django52' and extra == 'group-10-whitenoise-django61') or (extra == 'group-10-whitenoise-django60' and extra == 'group-10-whitenoise-django61')" },
-]
-
-[[package]]
 name = "sphinx-copybutton"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -965,7 +954,6 @@ docs = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'group-10-whitenoise-django52' and extra == 'group-10-whitenoise-django60') or (extra == 'group-10-whitenoise-django52' and extra == 'group-10-whitenoise-django61') or (extra == 'group-10-whitenoise-django60' and extra == 'group-10-whitenoise-django61')" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'group-10-whitenoise-django52' and extra == 'group-10-whitenoise-django60') or (extra == 'group-10-whitenoise-django52' and extra == 'group-10-whitenoise-django61') or (extra == 'group-10-whitenoise-django60' and extra == 'group-10-whitenoise-django61')" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'group-10-whitenoise-django52' and extra == 'group-10-whitenoise-django60') or (extra == 'group-10-whitenoise-django52' and extra == 'group-10-whitenoise-django61') or (extra == 'group-10-whitenoise-django60' and extra == 'group-10-whitenoise-django61')" },
-    { name = "sphinx-build-compatibility" },
     { name = "sphinx-copybutton" },
 ]
 test = [
@@ -989,7 +977,6 @@ django61 = [{ name = "django", marker = "python_full_version >= '3.12'", specifi
 docs = [
     { name = "furo", specifier = ">=2024.8.6" },
     { name = "sphinx", specifier = ">=7.4.7" },
-    { name = "sphinx-build-compatibility", git = "https://github.com/readthedocs/sphinx-build-compatibility?rev=4f304bd4562cdc96316f4fec82b264ca379d23e0" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
 ]
 test = [


### PR DESCRIPTION
The extension is [explicitly a temporary workaround](https://github.com/readthedocs/sphinx-build-compatibility) for Read the Docs no longer injecting variables into Sphinx’s html_context. The only ones Furo used were those behind the “edit this page” links, which it supports natively through theme options.
